### PR TITLE
Polish v3.0.0 docs, fix release blockers, make operators case-insensitive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+---
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/auto-qc/
+    permissions:
+      # Required for PyPI trusted publishing (OIDC). No API token needed.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,55 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
-## 3.0.0 - Unreleased
+## 3.0.0 - 2026-06-01
 
-- Update code from python 2.7 => ^3.7.
-- Rename flag: `--threshold-file` => `--thresholds`
-- Rename flag: `--analysis-file` => `--data`
-- Simplify the format of the `data` file: removed required metadata fields. Now
-  is just a plain JSON / YAML file.
-- Simplify the format of the `thresholds` file. Path to `auto-qc` version
-  changed from `metadata.auto_qc.version` => `version`.
-- Returns a non-zero exit if the QC tests do not pass.
-- Remove the fn library dependency. This library is no longer maintained.
+This is a major release that ports auto-qc to Python 3, modernises the packaging
+and command-line interface, and simplifies the input file formats. It is **not
+backwards compatible** with 2.x threshold or data files.
+
+### Changed
+
+- Ported the codebase from Python 2.7 to Python 3 (now requires Python 3.10+).
+- Rewrote the command-line interface using
+  [click](https://click.palletsprojects.com/):
+  - Renamed flag `--analysis-file` / `-a` => `--data` / `-d`.
+  - Renamed flag `--threshold-file` / `-t` => `--thresholds` / `-t`.
+  - Kept `--json-output` / `-j`.
+- Simplified the **data** file format: it is now a plain JSON / YAML dictionary
+  with no required metadata wrapper.
+- Simplified the **thresholds** file format: a top-level `version` and
+  `thresholds` list, where each entry is a dictionary with `name`, `fail_code`
+  and `rule` (and optional `pass_msg`, `fail_msg` and `tags`). The version field
+  moved from `metadata.auto_qc.version` => `version`.
+- Human-readable output now prints `PASS`, or `FAIL: <fail_code>, ...` listing
+  the codes of every rule that failed.
+- Threshold and data files are now validated up front with
+  [pydantic](https://docs.pydantic.dev/); invalid files report a clear error and
+  exit non-zero.
+
+### Added
+
+- A non-zero exit code is returned when any QC rule fails, so auto-qc can be
+  used directly in pipelines and CI.
+- Support for list-valued data references (used by the `is_in` / `is_not_in`
+  operators).
+- An `examples/` directory with a runnable example.
+
+### Removed
+
+- Removed the unmaintained `fn`, `funcy` and `python-termstyle` dependencies.
+  Runtime dependencies are now `click`, `pydantic`, `rich` and `PyYAML`.
+
+### Packaging & tooling
+
+- Replaced `setup.py` / `tox` with a PEP 621 `pyproject.toml` built by
+  [hatchling](https://hatch.pypa.io/), managed with
+  [uv](https://docs.astral.sh/uv/).
+- The version number is single-sourced from `auto_qc/version.py`.
+- Linting and formatting moved to [ruff](https://docs.astral.sh/ruff/); Markdown
+  is formatted with [prettier](https://prettier.io/).
+- Added a GitHub Actions workflow that runs the unit and feature tests, lints,
+  and builds the package on every push and pull request.
 
 ## 2.0.0 - 2018-02-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to auto-qc
+
+Thanks for your interest in improving auto-qc. This document covers how to set
+up a development environment, run the checks, and cut a release.
+
+## Development environment
+
+auto-qc uses [uv](https://docs.astral.sh/uv/) for dependency management and
+[ruff](https://docs.astral.sh/ruff/) for linting and formatting. Markdown is
+formatted with [prettier](https://prettier.io/) via `npx`, so a recent Node.js
+is needed for the formatting checks.
+
+Install the Python dependencies into a local virtual environment with:
+
+```console
+make bootstrap
+```
+
+## Running the checks
+
+The same checks that run in CI are available as `make` targets:
+
+```console
+make test        # run the unit tests with pytest
+make feature     # run the feature tests with behave
+make fmt         # auto-format the code (ruff) and Markdown (prettier)
+make fmt_check   # check formatting without changing files
+make build       # build the wheel and sdist into dist/
+```
+
+`make all` runs the formatting check, both test suites, and the build, which is
+the quickest way to confirm a change is ready to push.
+
+## Pull requests
+
+- Keep changes focused and add tests for new behaviour. Unit tests live in
+  `test/` and end-to-end feature tests live in `features/`.
+- Run `make fmt` before committing so the diff only contains meaningful changes.
+- Update `CHANGELOG.md` under the unreleased heading when your change is
+  user-facing.
+
+## Cutting a release
+
+1. Update the version string in `auto_qc/version.py`. This is the single source
+   of truth for the package version, the `--json-output` payload, and the
+   threshold-file `version` compatibility check.
+2. Move the relevant `CHANGELOG.md` entries under a new dated heading.
+3. Open a pull request and merge once CI is green.
+4. Tag the merge commit (`git tag vX.Y.Z && git push origin vX.Y.Z`) and publish
+   a GitHub release for that tag. The
+   [`release` workflow](.github/workflows/release.yml) builds the package and
+   publishes it to [PyPI](https://pypi.org/project/auto-qc/) automatically.
+
+Publishing uses PyPI
+[trusted publishing](https://docs.pypi.org/trusted-publishers/), so no API token
+is stored in the repository. The PyPI project must be configured to trust this
+repository's `release` workflow before the first automated publish.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-# auto-qc - A python tool for storing business logic as data.
+# auto-qc
+
+[![Tests](https://github.com/michaelbarton/auto-qc/actions/workflows/tests.yml/badge.svg)](https://github.com/michaelbarton/auto-qc/actions/workflows/tests.yml)
+[![PyPI version](https://img.shields.io/pypi/v/auto-qc.svg)](https://pypi.org/project/auto-qc/)
+[![Python versions](https://img.shields.io/pypi/pyversions/auto-qc.svg)](https://pypi.org/project/auto-qc/)
+[![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE.txt)
+
+**Keep your pass/fail rules in a data file, not buried in your code.**
+
+`auto-qc` reads a file of metrics and a file of pass/fail rules, evaluates one
+against the other, and tells you whether the metrics pass — and if not, exactly
+which rules failed. The rules live in plain YAML/JSON that a non-programmer can
+read and edit, so the thresholds can change without touching the pipeline.
 
 ## Quick Start
 
@@ -7,307 +19,355 @@ pip3 install auto-qc
 auto-qc --data <DATA_FILE> --thresholds <THRESHOLD_FILE>
 ```
 
+`auto-qc` prints `PASS` or `FAIL: <codes>` and exits non-zero on failure, so it
+drops straight into a shell pipeline or CI step.
+
 ## Motivation
 
-Auto QC is designed for business logic where process failures can be determined
-with clear thresholds rules, such as "defects per month > 10", but change often
-enough that hard-coding them into software with `if/else` or `case` statements
-would require regular changes to the code to adapt them according to moving
-requirements.
+`auto-qc` came out of running quality control on high-throughput DNA sequencing
+at the Joint Genome Institute. Every sequencing run produces a pile of metrics
+for each sample — contamination, coverage depth, base quality — and every sample
+has to be judged pass or fail against a set of thresholds.
 
-Auto QC solves this by providing a JSON/YAML data format for the business
-thresholds, which are evaluated against metrics stored in separate file. If any
-of the threshold rules evaluate to `False`, auto QC will report the
-corresponding error code associated with the failing rule.
+The catch is that those thresholds are not fixed. They move as protocols evolve,
+as instruments are recalibrated, and as the lab learns what "good" looks like.
+And the people who own those thresholds are the analysts and lab leads, not the
+software engineers who maintain the pipeline.
 
-## Simple Example
+Baking the rules into the pipeline as `if`/`else` statements meant that every
+time a cutoff moved, someone had to change code, get it reviewed, and redeploy —
+and you still had no clean record of _why_ a particular sample failed.
 
-![Auto QC Simple Example](img/simple_example.svg "Example Auto QC Files")
+`auto-qc` pulls that logic out of the code and into a data file:
 
-### Explanation
+- **Analysts own the rules.** Thresholds live in a YAML/JSON file anyone can
+  read and edit. No code change, no redeploy.
+- **The pipeline just runs a command.** It calls `auto-qc`, reads the exit code,
+  and optionally parses the JSON report of which rules failed and why.
+- **Failures are explained.** Each rule carries a `fail_code` (and an optional
+  human-readable message), so a failing sample comes with a machine-readable
+  reason instead of a mystery.
 
-Assume metrics for a widget looks like the data below. This kind of data may be
-captured during the manufacturing process, or from data aggregated from logs.
+Although it was born in a sequencing lab, the same shape of problem shows up
+anywhere pass/fail rules change more often than the code around them —
+manufacturing tolerances, data-pipeline quality gates, SLA checks, release
+readiness. If you have ever hard-coded a threshold and then had to redeploy to
+move it, `auto-qc` is for you.
+
+## How It Works
+
+![auto-qc takes a data file of metrics and a thresholds file of rules, and reports a pass or fail](img/simple_example.svg "auto-qc evaluates metrics against rules")
+
+Say a single sequencing sample produces these metrics:
 
 ```json
 {
-  "foo": 14.2,
-  "bar": -2
+  "contamination": { "percent_human": 0.4 },
+  "coverage": { "mean_depth": 18.6 }
 }
 ```
 
-And the threshold rules that the business cares about look like this:
+And the QC rules the lab currently cares about look like this:
 
 ```yaml
 version: 3.0.0
 thresholds:
-  - fail_code: "FOO_FAILURE"
-    rule: ["greater_than", ":foo", 10]
-  - fail_code: "BAR_FAILURE"
-    rule: ["greater_than", ":bar", 0]
+  - name: Contamination too high
+    fail_code: CONTAMINATION
+    rule: ["less_than", ":contamination/percent_human", 1.0]
+  - name: Coverage too low
+    fail_code: LOW_COVERAGE
+    rule: ["greater_than", ":coverage/mean_depth", 30]
 ```
 
-Running this with `auto-qc` would report the error `BAR_FAILURE`, because the
-value for `bar` in the data file is -2, while the thresholds includes a rule
-that the pointer to the value for `:bar` should not be below 0. Every rule
-defined in the `thresholds` field should evaluate to `True`. If any evaluate to
-`False` then auto QC will return the associated string in the `fail_code` field.
+Running `auto-qc` against these two files reports `FAIL: LOW_COVERAGE`. The
+contamination rule passes (`0.4` is less than `1.0`), but the coverage rule
+fails because the mean depth of `18.6` is not greater than `30`.
 
-### More-complex example
+A string beginning with `:` is a **pointer** into the data file:
+`:coverage/mean_depth` reads the `mean_depth` field nested under `coverage`.
+Every rule in the `thresholds` list must evaluate to `True` for the sample to
+pass. For each rule that evaluates to `False`, `auto-qc` reports the associated
+`fail_code`.
 
-More complex examples can be built using Boolean expressions such as `AND` or
-`OR`. Assume that the thresholds might depend on the type of widget being
-manufactured, where cheaper widgets could have more lax thresholds. This can be
-handled by encoding the widget type in the data file.
+### A More Complex Rule
+
+Rules are nestable [s-expressions][sexp], so they can combine `and`, `or` and
+`not` to express richer logic. Suppose the acceptable coverage depends on the
+library protocol, which is also recorded in the data file:
 
 ```json
 {
-  "widget_type": "cheap",
-  "foo": 14.2,
-  "bar": -2
+  "sample": { "protocol": "Low Input DNA" },
+  "coverage": { "mean_depth": 18.6 }
 }
 ```
 
-Then the thresholds file can use a mixture of `OR` and `AND` expressions to test
-the value of `:bar` based on the value of the `:widget_type` field.
+A single rule can then require a higher depth for standard libraries while
+allowing a lower depth for low-input ones:
 
 ```yaml
 version: 3.0.0
 thresholds:
-  - fail_code: "FOO_FAILURE"
-    rule: ["greater_than", ":foo", 10]
-  - fail_code: "BAR_FAILURE"
+  - name: Coverage below protocol threshold
+    fail_code: LOW_COVERAGE
     rule:
-      - OR
-      - - AND
-        - ["equals", ":widget_type", "cheap"]
-        - ["greater_than", ":bar", -5]
-      - - AND
-        - ["equals", ":widget_type", "expensive"]
-        - ["greater_than", ":bar", 2]
+      - or
+      - - and
+        - ["equals", ":sample/protocol", "Low Input DNA"]
+        - ["greater_than", ":coverage/mean_depth", 15]
+      - - and
+        - ["equals", ":sample/protocol", "Standard DNA"]
+        - ["greater_than", ":coverage/mean_depth", 30]
 ```
+
+[sexp]: https://en.wikipedia.org/wiki/S-expression
 
 ## Command Line Options
 
-- `-d`, `--data` <DATA_FILE>: The path to the file containing input data to be
-  checked.
+- `-d`, `--data` <DATA_FILE>: Path to the YAML/JSON file of metrics to check.
+- `-t`, `--thresholds` <THRESHOLD_FILE>: Path to the YAML/JSON file of pass/fail
+  rules.
+- `-j`, `--json-output`: Print a detailed JSON report instead of `PASS`/`FAIL`.
+- `-m`, `--manual`: Print the full manual and exit.
 
-- `-t`, `--thresholds` <THRESHOLD_FILE>: The path to the file containing the
-  pass/fail thresholds.
+`auto-qc` exits `0` when every rule passes and `1` when any rule fails or the
+input files are invalid.
 
-- `-j`, `--json-output`: Generate output as JSON.
+## Output
+
+By default `auto-qc` prints a single line: `PASS`, or `FAIL:` followed by the
+`fail_code` of every rule that failed.
+
+With `--json-output` it prints a structured report that downstream tooling can
+consume — the overall result, the list of failing codes, and an entry per rule
+with its name, pass/fail state, message and tags:
+
+```json
+{
+  "auto_qc_version": "3.0.0",
+  "fail_codes": ["LOW_COVERAGE"],
+  "pass": false,
+  "qc": [
+    {
+      "fail_code": "CONTAMINATION",
+      "message": "",
+      "name": "Contamination too high",
+      "pass": true,
+      "tags": []
+    },
+    {
+      "fail_code": "LOW_COVERAGE",
+      "message": "",
+      "name": "Coverage too low",
+      "pass": false,
+      "tags": []
+    }
+  ]
+}
+```
 
 ## Python API
 
-Auto QC can be used in python code as follows:
+`auto-qc` can also be called directly from Python. `run` takes the parsed
+thresholds and data as dictionaries and returns an evaluation object:
 
 ```python
+import yaml
 from auto_qc import main
-evaluation = main.run(thresholds, data)
+
+with open("qc_thresholds.yml") as thresholds, open("input_data.json") as data:
+    evaluation = main.run(yaml.safe_load(thresholds), yaml.safe_load(data))
+
+print(evaluation.is_pass)     # False
+print(evaluation.fail_codes)  # ['LOW_COVERAGE']
 ```
 
 ## File Syntax
 
-### Source Data File
+### Data File
 
-A data file is a YAML/JSON file containing all the data used to make decisions.
-This file should contain nested dictionaries. An example data file might look
-like:
+The data file is a YAML/JSON file of nested dictionaries containing all the
+metrics used to make decisions. There are no required fields — it is just your
+data. For example:
 
 ```yaml
 ---
-manufacturing:
-  defective_parts_per_million_per_month: 7
-  mean_throughput_per_machine_per_month: 1462.8
-customer:
-  percent_on_time_delivery: 97.3
-  returns_per_month: 31
+sample:
+  id: SRX-4521
+  protocol: Low Input DNA
+contamination:
+  percent_human: 0.4
+  percent_phix: 0.02
+coverage:
+  mean_depth: 18.6
+  percent_bases_above_30x: 88.1
+quality:
+  percent_q30: 91.2
 ```
 
-### Source Threshold File
+### Threshold File
 
-A threshold file specifies the QC criteria or business logic to make a pass or
-fail based on the fields and metrics in the data above file. The threshold file
-is a YAML/JSON dictionary contains two fields `version` and `thresholds`. These
-fields are defined as:
+The threshold file specifies the QC criteria. It is a YAML/JSON dictionary with
+two fields:
 
-- **version** - This field is checked by auto-qc to determine if the QC
-  threshold syntax matches that of the version of auto-qc being run. For the
-  current version of auto-qc this should be `3.0.0`. If the `version` field is
-  out of date, e.g. `2.x`, then auto-qc will immediately fail.
+- **version** — Checked by `auto-qc` to confirm the file matches the syntax of
+  the version being run. For this release it should be `3.0.0`. If the major
+  version is out of date (e.g. `2.x`), `auto-qc` fails immediately rather than
+  silently misreading the file.
 
-- **thresholds** - This field should contain a list of dictionaries, where each
-  entry defines a rule that should be evaluated against the metrics in the data
-  file. The threshold dictionaries are defined as follows in the next section.
+- **thresholds** — A list of rule dictionaries, each described below.
 
-### Evaluated Rules
+### Rules
 
-Use the example data above, a simple threshold file with two business rules
-might look like:
+Using the data above, a threshold file with two rules might look like:
 
 ```yaml
 version: 3.0.0
 thresholds:
-  - name: Dropping throughput rate
-    fail_code: ERR_001
+  - name: Contamination too high
+    fail_code: CONTAMINATION
+    fail_msg: "Human contamination is {contamination/percent_human}%"
     rule:
-      - LESS_THAN
-      - ":manufacturing/mean_throughput_per_machine_per_month"
-      - 10000
+      - less_than
+      - ":contamination/percent_human"
+      - 1.0
 
-  - name: Increasing defects
-    fail_code: ERR_002
+  - name: Coverage too low
+    fail_code: LOW_COVERAGE
     rule:
-      - OR
-      - [
-          GREATER_THAN,
-          ":manufacturing/defective_parts_per_million_per_month",
-          100,
-        ]
-      - ["GREATER_THAN", ":customer/returns_per_month", 10]
+      - or
+      - ["greater_than", ":coverage/mean_depth", 30]
+      - ["greater_than", ":coverage/percent_bases_above_30x", 90]
 ```
 
-The first rule 'Dropping throughput rate' checks the value in the data file for
-the path `:manufacturing/mean_throughput_per_machine_per_month` ensures it's
-greater than `10000`.
+The first rule checks that `:contamination/percent_human` is below `1.0`. The
+second is a compound rule joined by `OR`: the sample passes if _either_ the mean
+depth is above `30` _or_ at least `90`% of bases are above 30x coverage. This
+shows that every rule is a list beginning with an operator, and that rules can
+be nested arbitrarily.
 
-The second rule 'Increasing defects' is a compound rule joined by an `OR`
-operator, and checks two metrics in the data file to see if either are above a
-given threshold file. This second rule illustrates that all business rules are
-lists beginning with an operator, and can be arbitrarily nested. The full list
-of available operators is given below.
+Each rule dictionary contains:
 
-Each evaluation rule dictionary contains:
+- **name**: A unique name for the rule. _(required)_
 
-- **name**: A unique name for this business rule.
+- **fail_code**: An identifier for this kind of failure, reported when the rule
+  evaluates to fail. _(required)_
 
-- **fail_msg**: A message to generate if this entry QC entry fails. Python
-  string interpolation can be used to customise this message with values from
-  the data file.
+- **rule**: The s-expression to evaluate. _(required)_ It is made up of:
 
-- **pass_msg**: A message to generate if this entry passes. Python string
-  interpolation may also be used to customise this message with values from the
-  data file.
+  - **operator** — The test to apply, such as `greater_than` or a Boolean
+    operator such as `and`. The full list is below.
 
-- **fail_code**: An ID for the kind of failure identified if this entry
-  evaluates to fail. The list of failure codes is returned in the JSON output
-  with the flag.
+  - **pointer** — A value from the data file. A leading `:` marks the string as
+    a pointer; the rest is the `/`-separated path to the value.
 
-- **tags**: A optional list of tags for the QC entry. These tags are returned in
-  the JSON output if `--json-output` is used. These have no effect on the
-  evaluation of the tool, but can be useful for downstream processing of the
-  generated JSON output. E.g. process the failures and group by tags.
+  - **literal** — A literal value to compare the pointer against.
 
-- **rule**:
+- **fail_msg**: _(optional)_ A message generated when the rule fails. Python
+  string interpolation can pull in values from the data file, e.g.
+  `{coverage/mean_depth}`.
 
-  - **operator** - An operator to test the QC value. This may be mathematical
-    comparison operators such as 'greater_than' or Boolean operators such as
-    'AND'. The list of allowed operators is described in the section below.
+- **pass_msg**: _(optional)_ A message generated when the rule passes, with the
+  same interpolation support.
 
-  - **analysis value** - The value from the data file that should be tested. The
-    colon ':' indicates that this is a pointer to a value in the data file. The
-    remainder of this string is the path to the value to be evaluated against.
+- **tags**: _(optional)_ A list of tags returned in the JSON output. They have
+  no effect on evaluation but are useful for grouping or filtering failures
+  downstream.
 
-  - **literal value** - A literal value that to compare with the reference
-    value.
+### Available Operators
 
-### AVAILABLE OPERATORS
+Operator names are case-insensitive, so `or` and `OR` are equivalent.
 
-**equals** / **not_equals** - Test whether two values are equal or not.
+**equals** / **not_equals** — Test whether two values are equal.
 
 ```yaml
 - equals
-- ":run_metadata/protocol"
+- ":sample/protocol"
 - Low Input DNA
 ```
 
-**greater_than** / **less_than** / **greater_equal_than** /
-**less_equal_than** - Test whether one numeric value is greater/smaller than
-another.
+**greater_than** / **less_than** / **greater_equal_than** / **less_equal_than**
+— Test whether one numeric value is greater or smaller than another.
 
 ```yaml
-- greater_than
-- ":human_contamination/metrics/percent_contamination"
-- 5
+- less_than
+- ":contamination/percent_human"
+- 1.0
 ```
 
-**and** - Test whether two values are both true. The example here illustrates
-that metrics can be nested. For instance here, the two arguments to the **and**
-operator are themselves thresholds.
+**and** — Test whether all arguments are true. The arguments here are themselves
+rules, showing that rules nest.
 
 ```yaml
 - and
-- - greater_than
-  - ":cat_contamination/metrics/percent_contamination"
-  - 5
-- - greater_than
-  - ":dog_contamination/metrics/percent_contamination"
-  - 5
+- - less_than
+  - ":contamination/percent_human"
+  - 1.0
+- - less_than
+  - ":contamination/percent_phix"
+  - 0.1
 ```
 
-**or** - Test whether any values are true.
+**or** — Test whether any argument is true.
 
 ```yaml
 - or
 - - greater_than
-  - ":cat_contamination/metrics/percent_contamination"
-  - 5
+  - ":coverage/mean_depth"
+  - 30
 - - greater_than
-  - ":dog_contamination/metrics/percent_contamination"
-  - 5
+  - ":quality/percent_q30"
+  - 90
 ```
 
-**not** - Flips the Boolean value
+**not** — Flip a Boolean value.
 
 ```yaml
 - not
-- ":cat_contamination/is_contaminated"
+- ":sample/is_control"
 ```
 
-**is_in** / **is_not_in** - Test whether a value is in a list of values. Note
-that the list of values must begin with the **list** operator.
+**is_in** / **is_not_in** — Test whether a value is in a list of values. The
+list must begin with the **list** operator.
 
 ```yaml
 - is_in
-- ":cat_contamination/name_of_cat"
+- ":sample/protocol"
 - - list
-  - "Chase No Face"
-  - "Colonel Meow"
-  - "Felicette"
-  - "Mrs. Chippy"
-  - "Peter, the Lord's Cat"
-  - "Tiddles"
-  - "Wilberforce"
+  - Low Input DNA
+  - Standard DNA
+  - PCR-free
 ```
 
 ## Building and Testing
 
-Type `make` to get a full list of available commands for building and testing.
-The available commands are:
-
 This project uses [uv](https://docs.astral.sh/uv/) for dependency management and
 [ruff](https://docs.astral.sh/ruff/) for linting and formatting. Markdown is
-formatted with [prettier](https://prettier.io/) via `npx`.
+formatted with [prettier](https://prettier.io/) via `npx`. Type `make` for the
+full list of commands:
 
 ```console
 make bootstrap   Installs python dependencies locally
-make test        Runs all unit tests defined in the test/
-make feature     Runs all feature tests defined in the features/
+make test        Runs all unit tests defined in test/
+make feature     Runs all feature tests defined in features/
 make fmt         Formats code with ruff and prettier (markdown)
 make fmt_check   Checks code formatting with ruff and prettier
 make build       Builds a python package of auto_qc in dist/
 ```
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development and release workflow.
+
 ## Versioning
 
-This project aims to adhere to [Semantic Versioning](http://semver.org/) as much
-as possible. The project version history is described in the CHANGELOG. The
-version number is single-sourced from `auto_qc/version.py`; bump a release by
-editing the `__version__` string there.
+This project follows [Semantic Versioning](http://semver.org/); the history is
+recorded in the [CHANGELOG](CHANGELOG.md). The version number is single-sourced
+from `auto_qc/version.py` — bump a release by editing the `__version__` string
+there.
 
 ## Licence
 
-auto-qc Copyright (c) 2017-2021, The Regents of the University of California,
+auto-qc Copyright (c) 2017-2026, The Regents of the University of California,
 through Lawrence Berkeley National Laboratory (subject to receipt of any
 required approvals from the U.S. Dept. of Energy). All rights reserved.
 
@@ -324,13 +384,13 @@ its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the
 Software to reproduce, prepare derivative works, distribute copies to the
 public, perform publicly and display publicly, and to permit others to do so.
 
-## AUTHOR
+## Author
 
 Michael Barton <mail@michaelbarton.me.uk>
 
-## HISTORY
+## History
 
-- 3.0.0 - Mon 08 Feb 2021
+- 3.0.0 - Mon 01 Jun 2026
 - 2.0.0 - Mon 20 Jun 2016
 - 1.1.0 - Mon 27 Apr 2015
 - 1.0.0 - Fri 15 Aug 2014

--- a/auto_qc/MANUAL.md
+++ b/auto_qc/MANUAL.md
@@ -1,0 +1,97 @@
+# auto-qc
+
+Evaluate a file of metrics against a file of pass/fail rules, and report whether
+the metrics pass quality control.
+
+## Synopsis
+
+```
+auto-qc --data <DATA_FILE> --thresholds <THRESHOLD_FILE> [--json-output]
+```
+
+## Description
+
+`auto-qc` reads two files:
+
+- a **data** file of metrics (plain YAML/JSON), and
+- a **thresholds** file of pass/fail rules.
+
+It evaluates every rule against the data. If all rules pass it prints `PASS` and
+exits `0`. If any rule fails it prints `FAIL:` followed by the `fail_code` of
+each failing rule, and exits `1`. Keeping the rules in a data file lets the
+people who own the thresholds change them without changing the code that runs
+the check.
+
+## Options
+
+- `-d`, `--data` <DATA_FILE> — Path to the YAML/JSON file of metrics.
+- `-t`, `--thresholds` <FILE> — Path to the YAML/JSON file of rules.
+- `-j`, `--json-output` — Print a detailed JSON report instead of PASS/FAIL.
+- `-m`, `--manual` — Print this manual and exit.
+
+## Data file
+
+A dictionary of nested metrics. There are no required fields:
+
+```yaml
+sample:
+  protocol: Low Input DNA
+contamination:
+  percent_human: 0.4
+coverage:
+  mean_depth: 18.6
+```
+
+## Threshold file
+
+A dictionary with two fields, `version` and `thresholds`:
+
+```yaml
+version: 3.0.0
+thresholds:
+  - name: Coverage too low
+    fail_code: LOW_COVERAGE
+    rule: ["greater_than", ":coverage/mean_depth", 30]
+```
+
+- **version** must match the major version of `auto-qc` being run, or the tool
+  exits with an error.
+- **thresholds** is a list of rules. Each rule is a dictionary with:
+  - **name** (required) — a unique name for the rule.
+  - **fail_code** (required) — the code reported when the rule fails.
+  - **rule** (required) — the expression to evaluate (see below).
+  - **fail_msg** / **pass_msg** (optional) — messages with `{path/to/value}`
+    interpolation from the data file.
+  - **tags** (optional) — labels returned in the JSON output.
+
+## Rules
+
+A rule is a list beginning with an operator. A string beginning with `:` is a
+pointer into the data file; its `/`-separated path locates the value. Rules nest
+arbitrarily using the Boolean operators.
+
+A sample passes only when every rule evaluates to `True`.
+
+## Operators
+
+- **equals**, **not_equals** — compare two values for equality.
+- **greater_than**, **less_than**, **greater_equal_than**, **less_equal_than** —
+  compare two numbers.
+- **and**, **or** — combine nested rules.
+- **not** — flip a Boolean value.
+- **is_in**, **is_not_in** — test membership in a `list`.
+
+```yaml
+- or
+- ["greater_than", ":coverage/mean_depth", 30]
+- ["greater_than", ":quality/percent_q30", 90]
+```
+
+## Exit codes
+
+- `0` — all rules passed.
+- `1` — one or more rules failed, or the input files were invalid.
+
+## See also
+
+Full documentation: https://github.com/michaelbarton/auto-qc

--- a/auto_qc/node.py
+++ b/auto_qc/node.py
@@ -22,7 +22,7 @@ OPERATORS = {
 
 
 def is_operator(v):
-    return v in OPERATORS.keys()
+    return isinstance(v, str) and v.lower() in OPERATORS
 
 
 def has_doc_dict(qc_node):
@@ -88,5 +88,6 @@ def evaluate_rule(node: typing.List[typing.Any]) -> bool:
       FALSE
     """
     args = list(map(functional.recursive_apply(evaluate_rule), node[1:]))
-    qc_func = OPERATORS[node[0]]
+    op = node[0]
+    qc_func = OPERATORS[op.lower() if isinstance(op, str) else op]
     return qc_func(*args)

--- a/auto_qc/object.py
+++ b/auto_qc/object.py
@@ -38,7 +38,7 @@ class AutoQC(pydantic.BaseModel):
                 textwrap.dedent(
                     f"""
             Incompatible threshold file syntax: {ver}.
-            Please update the syntax to version >= {version.__version__}.0.0.
+            Please update the syntax to version >= {version.__version__}.
                     """
                 )
             )

--- a/auto_qc/variable.py
+++ b/auto_qc/variable.py
@@ -13,10 +13,16 @@ def is_variable(var: str) -> bool:
 def is_variable_path_valid(data: typing.Dict[str, typing.Any], path: str) -> bool:
     """
     Does the variable path have a matching path in the analysis?
+
+    Checks for the existence of the key path rather than the truthiness of the
+    value so that a legitimately null/zero/false value is not reported as a
+    missing metric.
     """
-    value = get_variable_value(data, path)
-    if value is None:
-        return False
+    node = data
+    for key in path[1:].split("/"):
+        if not isinstance(node, dict) or key not in node:
+            return False
+        node = node[key]
     return True
 
 

--- a/img/simple_example.svg
+++ b/img/simple_example.svg
@@ -1,327 +1,54 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="155mm"
-   height="320mm"
-   viewBox="0 0 155 320"
-   version="1.1"
-   id="svg8"
-   inkscape:version="1.0.1 (c497b03c, 2020-09-10)"
-   sodipodi:docname="simple_example.svg"
-   inkscape:export-filename="/Users/michaelbarton/Desktop/drawing.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
-  <defs
-     id="defs2">
-    <rect
-       x="93.009796"
-       y="55.324791"
-       width="115.30222"
-       height="122.46829"
-       id="rect32" />
-    <rect
-       x="41.426777"
-       y="62.2738"
-       width="76.171822"
-       height="53.453903"
-       id="rect26" />
-    <rect
-       x="49.979401"
-       y="97.820648"
-       width="37.417732"
-       height="40.090427"
-       id="rect20" />
-    <rect
-       x="41.426777"
-       y="62.2738"
-       width="203.65939"
-       height="47.573971"
-       id="rect62" />
-  </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.86013254"
-     inkscape:cx="315.35697"
-     inkscape:cy="741.02472"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer2"
-     inkscape:document-rotation="0"
-     showgrid="true"
-     showguides="true"
-     inkscape:window-width="1440"
-     inkscape:window-height="855"
-     inkscape:window-x="0"
-     inkscape:window-y="23"
-     inkscape:window-maximized="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid114"
-       units="mm"
-       spacingx="5"
-       spacingy="5"
-       empspacing="5" />
-  </sodipodi:namedview>
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:groupmode="layer"
-     id="layer2"
-     inkscape:label="Background"
-     style="display:inline">
-    <rect
-       style="display:inline;fill:#f2f2f2;fill-rule:evenodd;stroke-width:0.264583"
-       id="rect16"
-       width="125"
-       height="150"
-       x="15"
-       y="90"
-       ry="4" />
-    <rect
-       style="display:inline;fill:#f2f2f2;fill-rule:evenodd;stroke-width:0.264583"
-       id="rect36"
-       width="125"
-       height="60"
-       x="15"
-       y="15"
-       ry="4" />
-    <rect
-       style="display:inline;fill:#f2f2f2;fill-rule:evenodd;stroke-width:0.264583"
-       id="rect50"
-       width="125"
-       height="55"
-       x="15"
-       y="250"
-       ry="4" />
-  </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="headers"
-     style="display:inline">
-    <g
-       id="g141"
-       style="fill:#333333"
-       transform="translate(-10,-14.125)">
-      <rect
-         id="rect133"
-         width="125"
-         height="10"
-         x="25"
-         y="105"
-         ry="0"
-         style="display:inline;fill:#333333;stroke-width:0.264583" />
-      <rect
-         id="rect38"
-         width="125"
-         height="15.875"
-         x="25"
-         y="99.125"
-         ry="4"
-         style="display:inline;fill:#333333;stroke-width:0.264583" />
-    </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="19.871128"
-       y="94.038849"
-       id="text42"><tspan
-         sodipodi:role="line"
-         id="tspan40"
-         x="19.871128"
-         y="94.038849"
-         style="font-size:4.93889px;fill:#ffffff;stroke-width:0.264583">qc_thresholds.yml</tspan></text>
-    <g
-       id="g137"
-       style="fill:#333333"
-       transform="translate(-10,-10)">
-      <rect
-         id="rect130"
-         width="125"
-         height="10"
-         x="25"
-         y="30"
-         ry="0"
-         style="display:inline;fill:#333333;stroke-width:0.264583" />
-      <rect
-         id="rect44"
-         width="125"
-         height="15"
-         x="25"
-         y="25"
-         ry="4"
-         style="display:inline;fill:#333333;stroke-width:0.264583" />
-    </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:4.93889px;line-height:1.25;font-family:sans-serif;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.264583"
-       x="22.804745"
-       y="24.671997"
-       id="text48"><tspan
-         sodipodi:role="line"
-         id="tspan46"
-         x="22.804745"
-         y="24.671997"
-         style="font-size:4.93889px;fill:#ffffff;stroke-width:0.264583">input_data.json</tspan></text>
-  </g>
-  <g
-     inkscape:label="Code text"
-     inkscape:groupmode="layer"
-     id="layer1"
-     style="display:inline">
-    <text
-       xml:space="preserve"
-       id="text18"
-       style="font-style:normal;font-weight:normal;font-size:10.58329999999999949px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect20);fill:#000000;fill-opacity:1;stroke:none;" />
-    <text
-       xml:space="preserve"
-       id="text30"
-       style="font-style:normal;font-weight:normal;font-size:5.25133000000000028px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect32);fill:#000000;fill-opacity:1;stroke:none;"
-       transform="matrix(1.0841072,0,0,1.0748601,-75.832557,49.856982)"><tspan
-         x="93.009766"
-         y="60.286726"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata"># This file defines business logic as
-</tspan></tspan><tspan
-         x="93.009766"
-         y="67.022447"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata"># a list of YAML rules.
-</tspan></tspan><tspan
-         x="93.009766"
-         y="73.758169"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">#
-</tspan></tspan><tspan
-         x="93.009766"
-         y="80.493894"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata"># Pointers to values in the data file
-</tspan></tspan><tspan
-         x="93.009766"
-         y="87.229612"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata"># begin with &quot;&amp;&quot;
-</tspan></tspan><tspan
-         x="93.009766"
-         y="93.96533"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">#
-</tspan></tspan><tspan
-         x="93.009766"
-         y="100.70105"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata"># If any rule evaluates to `False`
-</tspan></tspan><tspan
-         x="93.009766"
-         y="107.43677"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata"># a failure message is generated.
-</tspan></tspan><tspan
-         x="93.009766"
-         y="114.17248"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">
-</tspan></tspan><tspan
-         x="93.009766"
-         y="120.9082"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">version: 3.0.0
-</tspan></tspan><tspan
-         x="93.009766"
-         y="127.64392"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">thresholds:
-</tspan></tspan><tspan
-         x="93.009766"
-         y="134.37964"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">
-</tspan></tspan><tspan
-         x="93.009766"
-         y="141.11535"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">- fail_code: FOO_FAIL
-</tspan></tspan><tspan
-         x="93.009766"
-         y="147.85107"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">  rule: [&quot;greater_than&quot;, &quot;&amp;foo&quot;, 10]
-</tspan></tspan><tspan
-         x="93.009766"
-         y="154.58679"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">
-</tspan></tspan><tspan
-         x="93.009766"
-         y="161.32251"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">- fail_code: BAR_FAIL
-</tspan></tspan><tspan
-         x="93.009766"
-         y="168.05823"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.25133px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">  rule: [&quot;greater_than&quot;, &quot;&amp;bar&quot;, 0]</tspan><tspan
-           style="shape-inside:url(#rect32)">
-</tspan></tspan></text>
-    <text
-       xml:space="preserve"
-       id="text24"
-       style="font-style:normal;font-weight:normal;font-size:5.64444000000000035px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect26);fill:#000000;fill-opacity:1;stroke:none;"
-       transform="translate(-16.427734,-24.017035)"><tspan
-         x="41.427734"
-         y="67.607433"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">{
-</tspan></tspan><tspan
-         x="41.427734"
-         y="74.847386"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">  &quot;foo&quot;: 14.2,
-</tspan></tspan><tspan
-         x="41.427734"
-         y="82.087338"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">  &quot;bar&quot;: -2
-</tspan></tspan><tspan
-         x="41.427734"
-         y="89.32729"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">}</tspan><tspan
-           style="font-size:5.64444px">
-</tspan></tspan></text>
-    <text
-       xml:space="preserve"
-       id="text54"
-       style="font-style:normal;font-weight:normal;font-size:5.64444000000000035px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect62);fill:#000000;fill-opacity:1;stroke:none;"
-       transform="translate(-21.427734,196.06145)"><tspan
-         x="41.427734"
-         y="67.607433"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">$ auto-qc
-</tspan></tspan><tspan
-         x="41.427734"
-         y="74.847386"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">    --data input_data.json 
-</tspan></tspan><tspan
-         x="41.427734"
-         y="82.087338"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">    --thresholds qc_threshold.yml
-</tspan></tspan><tspan
-         x="41.427734"
-         y="89.32729"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.64444px;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">
-</tspan></tspan><tspan
-         x="41.427734"
-         y="96.567242"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Inconsolata;-inkscape-font-specification:Inconsolata">FAIL: BAR_FAILURE</tspan><tspan
-           style="font-size:5.64444px">
-</tspan></tspan></text>
-    <rect
-       style="fill:#ffffff;stroke-width:0.264583"
-       id="rect92"
-       width="0.13363476"
-       height="4.9444861"
-       x="77.066803"
-       y="166.73615"
-       ry="0.06681738" />
-  </g>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="560" viewBox="0 0 600 560" font-family="sans-serif">
+  <style>
+    .mono { font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 12.5px; }
+    .file { fill: #1f2328; }
+    .comment { fill: #6e7781; }
+    .pointer { fill: #0550ae; }
+    .label { fill: #ffffff; font-size: 12px; font-weight: 600; }
+    .term { fill: #c9d1d9; }
+  </style>
+
+  <!-- Data file -->
+  <rect x="20" y="20" width="560" height="118" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+  <path d="M20 26 a6 6 0 0 1 6 -6 h548 a6 6 0 0 1 6 6 v18 h-560 z" fill="#2d333b"/>
+  <text x="34" y="37" class="label">input_data.json — metrics from one sequencing sample</text>
+  <text xml:space="preserve" class="mono file">
+    <tspan x="36" y="70">{</tspan>
+    <tspan x="36" y="89">  "contamination": { "percent_human": 0.4 },</tspan>
+    <tspan x="36" y="108">  "coverage":      { "mean_depth": 18.6 }</tspan>
+    <tspan x="36" y="127">}</tspan>
+  </text>
+
+  <text x="300" y="158" text-anchor="middle" fill="#6e7781" font-size="16">&#9660;</text>
+
+  <!-- Thresholds file -->
+  <rect x="20" y="168" width="560" height="248" rx="6" fill="#f6f8fa" stroke="#d0d7de"/>
+  <path d="M20 174 a6 6 0 0 1 6 -6 h548 a6 6 0 0 1 6 6 v18 h-560 z" fill="#2d333b"/>
+  <text x="34" y="185" class="label">qc_thresholds.yml — the pass/fail rules, owned by analysts</text>
+  <text xml:space="preserve" class="mono">
+    <tspan x="36" y="218" class="comment"># Pointers into the data file begin with ":".</tspan>
+    <tspan x="36" y="237" class="comment"># Edit these rules to change what passes — no code change.</tspan>
+    <tspan x="36" y="262" class="file">version: 3.0.0</tspan>
+    <tspan x="36" y="281" class="file">thresholds:</tspan>
+    <tspan x="36" y="306" class="file">  - name: Contamination too high</tspan>
+    <tspan x="36" y="325" class="file">    fail_code: CONTAMINATION</tspan>
+  </text>
+  <text xml:space="preserve" class="mono file"><tspan x="36" y="344">    rule: ["less_than", "</tspan><tspan class="pointer">:contamination/percent_human</tspan><tspan>", 1.0]</tspan></text>
+  <text xml:space="preserve" class="mono">
+    <tspan x="36" y="369" class="file">  - name: Coverage too low</tspan>
+    <tspan x="36" y="388" class="file">    fail_code: LOW_COVERAGE</tspan>
+  </text>
+  <text xml:space="preserve" class="mono file"><tspan x="36" y="407">    rule: ["greater_than", "</tspan><tspan class="pointer">:coverage/mean_depth</tspan><tspan>", 30]</tspan></text>
+
+  <text x="300" y="436" text-anchor="middle" fill="#6e7781" font-size="16">&#9660;</text>
+
+  <!-- Terminal -->
+  <rect x="20" y="446" width="560" height="98" rx="6" fill="#0d1117" stroke="#0d1117"/>
+  <path d="M20 452 a6 6 0 0 1 6 -6 h548 a6 6 0 0 1 6 6 v18 h-560 z" fill="#161b22"/>
+  <text x="34" y="463" class="label">terminal</text>
+  <text xml:space="preserve" class="mono term">
+    <tspan x="36" y="497">$ auto-qc --data input_data.json --thresholds qc_thresholds.yml</tspan>
+  </text>
+  <text xml:space="preserve" class="mono"><tspan x="36" y="524" fill="#f85149" font-weight="700">FAIL: LOW_COVERAGE</tspan></text>
 </svg>

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -11,6 +11,16 @@ def test_eval_less_than_with_two_literals():
     assert not node.evaluate_rule(n)
 
 
+def test_operators_are_case_insensitive():
+    assert node.is_operator("OR")
+    assert node.is_operator("Greater_Than")
+    assert node.evaluate_rule(["AND", ["GREATER_THAN", 2, 1], ["greater_than", 3, 1]])
+
+
+def test_non_string_is_not_an_operator():
+    assert not node.is_operator(5)
+
+
 def test_eval_true_with_nested_lists():
     n = ["and", ["greater_than", 2, 1], ["greater_than", 2, 1]]
     assert node.evaluate_rule(n)
@@ -66,4 +76,4 @@ def test_get_all_operators_with_nested_threshold():
 
 def test_get_all_operators_with_doc_string():
     n = ["less_than", 2, 1]
-    node.get_all_operators(n) == ["less_than"]
+    assert node.get_all_operators(n) == ["less_than"]

--- a/test/test_variable.py
+++ b/test/test_variable.py
@@ -21,4 +21,4 @@ def test_get_variables_with_no_nesting():
 def test_get_variables_with_nesting():
     qc_node = [["and", ["or", [":ref/metric_1", 2, 1], [":ref/metric_2", 2, 1]]]]
     expected = [":ref/metric_1", ":ref/metric_2"]
-    variable.get_variable_names(qc_node) == expected
+    assert variable.get_variable_names(qc_node) == expected


### PR DESCRIPTION
Final polish to get `v3.0.0` ready to merge into `master`. The v3 code was
already in good shape (tests green, modern packaging); the gaps were in the
docs/UX and a few correctness bugs that the test suite didn't catch.

## Documentation

- **Rewrite the README around auto-qc's real origin** (sequencing QC at the
  JGI), running one coherent worked example — contamination / coverage depth —
  through the whole document. Replaces the previous half-genericised
  manufacturing-widget framing and the leftover bioinformatics/cat examples
  (`cat_contamination`, "Colonel Meow") in the operators section.
- **Every documented example now runs as written.** They previously omitted the
  required `name` field and failed pydantic validation when copy-pasted; `name`
  is now present throughout.
- **Populate `auto_qc/MANUAL.md`.** It had been a 0-byte placeholder in every
  commit since the Python-3 upgrade, so `auto-qc --manual` printed an empty
  page. It now ships a real reference (bundled in the wheel).
- **Regenerate `img/simple_example.svg`** to match the new example. The old
  diagram used the wrong `&` pointer syntax (the code uses `:`).
- Add README badges, an Output section, a runnable Python API snippet, a
  `CONTRIBUTING.md`, and rewrite the `3.0.0` CHANGELOG entry with the full,
  dated change set.

## Fixes

- **Version-mismatch error** printed `version >= 3.0.0.0.0` → now `3.0.0`.
- **Operators are now case-insensitive** so `OR`, `and`, `GREATER_THAN` all
  work. The README's compound example used `OR`/`AND`, which the code had
  rejected as "Unknown operator".
- **`is_variable_path_valid`** checked truthiness, so a legitimately
  null/zero/false metric was reported as a missing path; it now checks key
  existence.
- Add the missing `assert` to two unit tests that silently never asserted.

## Release

- Add a PyPI publish workflow (`.github/workflows/release.yml`) using trusted
  publishing — no stored token.

## Verification

- `pytest`: 29 passed · `behave`: 53 scenarios passed
- `ruff check` / `ruff format --check` clean · `prettier --check` clean
- `uv build`: wheel + sdist at `3.0.0`, `MANUAL.md` bundled
- Ran the README's exact examples and confirmed the printed `PASS`/`FAIL` and
  JSON output match the docs.

https://claude.ai/code/session_01NNppfRtPdhcLXVUawbXAkJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNppfRtPdhcLXVUawbXAkJ)_