### PR TITLE
Harden and extend the s-expression engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,24 @@ backwards compatible** with 2.x threshold or data files.
 - A non-zero exit code is returned when any QC rule fails, so auto-qc can be
   used directly in pipelines and CI.
 - Support for list-valued data references (used by the `is_in` / `is_not_in`
-  operators).
+  operators). The membership list can now be written inline, without the
+  explicit `list` keyword.
+- New operators that make rules more expressive without leaving the s-expression
+  syntax: `between` (inclusive range); `add`, `subtract`, `multiply` and
+  `divide` (arithmetic over derived values such as ratios); `matches`,
+  `starts_with`, `ends_with` and `contains` (string and collection predicates);
+  and `length`.
+- Friendly, single `AutoQCError` for rules that can't be evaluated. Type
+  mismatches (e.g. comparing a number to text or to a missing metric) and
+  operators given the wrong number of arguments now report a clear message
+  naming the rule, instead of raising an uncaught Python traceback. Argument
+  counts are validated up front.
+- `--data` and `--thresholds` accept `-` to read a document from standard input,
+  so auto-qc fits a shell pipeline without a temp file.
+- A `--version` / `-V` flag.
+- The `--json-output` report now includes a machine-readable `explain` tree for
+  each rule (every operator with its result, every pointer resolved to its
+  value), so downstream tooling can show why a rule failed.
 - An `examples/` directory with runnable examples.
 - An `--explain` / `-e` flag that prints a tree showing how every rule was
   evaluated, with each metric pointer resolved to its value and the passing and

--- a/README.md
+++ b/README.md
@@ -138,9 +138,11 @@ thresholds:
 
 ## Command Line Options
 
-- `-d`, `--data` <DATA_FILE>: Path to the YAML/JSON file of metrics to check.
+- `-d`, `--data` <DATA_FILE>: Path to the YAML/JSON file of metrics to check, or
+  `-` to read the metrics from standard input.
 - `-t`, `--thresholds` <THRESHOLD_FILE>: Path to the YAML/JSON file of pass/fail
-  rules.
+  rules, or `-` to read the rules from standard input. (Only one of `--data` and
+  `--thresholds` can read from stdin at a time.)
 - `-j`, `--json-output`: Print a detailed JSON report instead of `PASS`/`FAIL`.
 - `-e`, `--explain`: Print a tree explaining how every rule was evaluated, with
   each metric pointer resolved to its value and the passing/failing branches
@@ -148,6 +150,7 @@ thresholds:
 - `-T`, `--test` <SUITE_FILE>: Run a suite of test cases against its thresholds
   file (see [Testing your rules](#testing-your-rules)).
 - `-m`, `--manual`: Print the full manual and exit.
+- `-V`, `--version`: Print the version and exit.
 
 `auto-qc` exits `0` when every rule passes and `1` when any rule fails or the
 input files are invalid.
@@ -159,7 +162,10 @@ By default `auto-qc` prints a single line: `PASS`, or `FAIL:` followed by the
 
 With `--json-output` it prints a structured report that downstream tooling can
 consume — the overall result, the list of failing codes, and an entry per rule
-with its name, pass/fail state, message and tags:
+with its name, pass/fail state, message, tags, and an `explain` tree giving the
+machine-readable evaluation of the rule (each operator with its result, and each
+pointer resolved to its value), so a dashboard can show _why_ a rule failed
+without re-running the tool:
 
 ```json
 {
@@ -168,18 +174,19 @@ with its name, pass/fail state, message and tags:
   "pass": false,
   "qc": [
     {
-      "fail_code": "CONTAMINATION",
-      "message": "",
-      "name": "Contamination too high",
-      "pass": true,
-      "tags": []
-    },
-    {
       "fail_code": "LOW_COVERAGE",
       "message": "",
       "name": "Coverage too low",
       "pass": false,
-      "tags": []
+      "tags": [],
+      "explain": {
+        "operator": "greater_than",
+        "result": false,
+        "args": [
+          { "variable": ":coverage/mean_depth", "value": 18.6 },
+          { "literal": 30 }
+        ]
+      }
     }
   ]
 }
@@ -367,6 +374,39 @@ Operator names are case-insensitive, so `or` and `OR` are equivalent.
 - 1.0
 ```
 
+**between** — Test whether a value lies within an inclusive range
+(`low <= value <= high`), which reads better than combining two comparisons.
+
+```yaml
+- between
+- ":coverage/mean_depth"
+- 30
+- 60
+```
+
+**add** / **subtract** / **multiply** / **divide** — Arithmetic on numeric
+values, so a rule can test a derived quantity such as a ratio without
+pre-computing it upstream. `add` and `multiply` take two or more arguments;
+`subtract` and `divide` take exactly two.
+
+```yaml
+- greater_than
+- ["divide", ":reads/mapped", ":reads/total"]
+- 0.95
+```
+
+**matches** / **starts_with** / **ends_with** — Test a string value against a
+regular expression, prefix, or suffix.
+
+```yaml
+- matches
+- ":sample/id"
+- "^SRX-[0-9]+$"
+```
+
+**contains** — Test whether a string or list value contains another value.
+**length** — The length of a string or list, for use inside another comparison.
+
 **and** — Test whether all arguments are true. The arguments here are themselves
 rules, showing that rules nest.
 
@@ -399,16 +439,14 @@ rules, showing that rules nest.
 - ":sample/is_control"
 ```
 
-**is_in** / **is_not_in** — Test whether a value is in a list of values. The
-list must begin with the **list** operator.
+**is_in** / **is_not_in** — Test whether a value is in a list of values. Write
+the list inline; only a list whose first element is itself an operator needs the
+explicit **list** keyword to mark it as data rather than a rule.
 
 ```yaml
 - is_in
 - ":sample/protocol"
-- - list
-  - Low Input DNA
-  - Standard DNA
-  - PCR-free
+- [Low Input DNA, Standard DNA, PCR-free]
 ```
 
 ## Building and Testing

--- a/auto_qc/MANUAL.md
+++ b/auto_qc/MANUAL.md
@@ -24,13 +24,17 @@ the check.
 
 ## Options
 
-- `-d`, `--data` <DATA_FILE> — Path to the YAML/JSON file of metrics.
-- `-t`, `--thresholds` <FILE> — Path to the YAML/JSON file of rules.
+- `-d`, `--data` <DATA_FILE> — Path to the YAML/JSON file of metrics, or `-` for
+  standard input.
+- `-t`, `--thresholds` <FILE> — Path to the YAML/JSON file of rules, or `-` for
+  standard input. Only one of `--data` / `--thresholds` may use stdin at once.
 - `-j`, `--json-output` — Print a detailed JSON report instead of PASS/FAIL.
+  Each rule includes an `explain` tree describing how it was evaluated.
 - `-e`, `--explain` — Print a tree explaining how every rule was evaluated.
 - `-T`, `--test` <SUITE_FILE> — Run a suite of test cases against its thresholds
   file.
 - `-m`, `--manual` — Print this manual and exit.
+- `-V`, `--version` — Print the version and exit.
 
 ## Data file
 
@@ -80,9 +84,20 @@ A sample passes only when every rule evaluates to `True`.
 - **equals**, **not_equals** — compare two values for equality.
 - **greater_than**, **less_than**, **greater_equal_than**, **less_equal_than** —
   compare two numbers.
+- **between** — test that a value is within an inclusive range (`low`, `high`).
+- **add**, **subtract**, **multiply**, **divide** — arithmetic on numbers, for
+  rules over derived values such as ratios.
 - **and**, **or** — combine nested rules.
 - **not** — flip a Boolean value.
-- **is_in**, **is_not_in** — test membership in a `list`.
+- **is_in**, **is_not_in** — test membership in a list (written inline).
+- **contains** — test that a string or list contains a value.
+- **matches**, **starts_with**, **ends_with** — test a string against a regular
+  expression, prefix, or suffix.
+- **length** — the length of a string or list.
+
+A rule that uses an operator on incompatible types — comparing a number to text,
+or to a missing metric — reports a clear error naming the rule, rather than
+crashing.
 
 ```yaml
 - or

--- a/auto_qc/core.py
+++ b/auto_qc/core.py
@@ -28,6 +28,7 @@ def build(thresholds: dict[str, typing.Any], data: dict[str, typing.Any]) -> mod
 
     error.check_node_paths(state)
     error.check_operators(state)
+    error.check_arity(state)
     return state
 
 

--- a/auto_qc/evaluate/error.py
+++ b/auto_qc/evaluate/error.py
@@ -45,18 +45,72 @@ def check_node_paths(state: models.AutoQC) -> None:
         raise exception.AutoQCError("\n".join(messages))
 
 
+def _check_node_operators(expr: typing.Any, rule_position: bool, errors: list[str]) -> None:
+    """Validate operators in ``expr``, knowing whether a rule is expected here.
+
+    In *rule position* (the top of a threshold, or an argument to ``and`` /
+    ``or`` / ``not``) a list must be led by a known operator; a list that isn't
+    is reported as an unknown operator, with a did-you-mean hint. In *value
+    position* a non-operator list is a legitimate literal list (e.g. the set for
+    ``is_in``), so only its nested applications are checked.
+    """
+    if not isinstance(expr, list) or not expr:
+        return
+
+    head = expr[0]
+    if node.is_operator(head):
+        argument_rule_position = head.lower() in node.RULE_POSITION_OPERATORS
+        for argument in expr[1:]:
+            _check_node_operators(argument, argument_rule_position, errors)
+    elif rule_position:
+        message = f"Unknown operator '{head}.'{_suggest(str(head), node.OPERATORS)}"
+        if message not in errors:
+            errors.append(message)
+    else:
+        for element in expr:
+            _check_node_operators(element, False, errors)
+
+
 def check_operators(state: models.AutoQC) -> None:
     """
     Checks that all operators listed in the QC file are valid. Raises an error
     listing each unknown operator, with a suggestion for the closest match.
     """
-    operators = list(
-        itertools.chain.from_iterable(node.get_all_operators(x.rule) for x in state.thresholds)
-    )
-    errors = {x for x in operators if not node.is_operator(x)}
+    errors: list[str] = []
+    for threshold in state.thresholds:
+        _check_node_operators(threshold.rule, rule_position=True, errors=errors)
 
     if errors:
-        messages = [
-            f"Unknown operator '{x}.'{_suggest(str(x), node.OPERATORS)}" for x in sorted(errors)
-        ]
-        raise exception.AutoQCError("\n".join(messages))
+        raise exception.AutoQCError("\n".join(errors))
+
+
+def _check_node_arity(expr: typing.Any, errors: list[str]) -> None:
+    """Validate operator argument counts throughout ``expr``."""
+    if not isinstance(expr, list) or not expr:
+        return
+
+    if node.is_operator(expr[0]):
+        op = node.OPERATORS[expr[0].lower()]
+        given = len(expr) - 1
+        if given < op.min_args or (op.max_args is not None and given > op.max_args):
+            message = node.arity_message(expr[0], op, given)
+            if message not in errors:
+                errors.append(message)
+        for argument in expr[1:]:
+            _check_node_arity(argument, errors)
+    else:
+        for element in expr:
+            _check_node_arity(element, errors)
+
+
+def check_arity(state: models.AutoQC) -> None:
+    """
+    Checks that every operator is given a valid number of arguments. Raises an
+    error listing each operator called with the wrong arity.
+    """
+    errors: list[str] = []
+    for threshold in state.thresholds:
+        _check_node_arity(threshold.rule, errors)
+
+    if errors:
+        raise exception.AutoQCError("\n".join(errors))

--- a/auto_qc/evaluate/exception.py
+++ b/auto_qc/evaluate/exception.py
@@ -5,3 +5,14 @@ class VersionNumberException(AutoQCError):
     """Incorrect version number error."""
 
     pass
+
+
+class EvaluationError(AutoQCError):
+    """Raised when a rule cannot be evaluated, e.g. comparing a number to text.
+
+    A subclass of :class:`~auto_qc.exception.AutoQCError` so that callers only
+    ever need to catch ``AutoQCError``. Carries an operator-level message; the
+    caller adds the rule name for context.
+    """
+
+    pass

--- a/auto_qc/evaluate/qc.py
+++ b/auto_qc/evaluate/qc.py
@@ -1,6 +1,7 @@
 import typing
 
 from auto_qc import models, node, variable
+from auto_qc.exception import AutoQCError
 
 
 def evaluate(state: models.AutoQC) -> models.AutoQCEvaluation:
@@ -20,30 +21,10 @@ def evaluate(state: models.AutoQC) -> models.AutoQCEvaluation:
 def create_variable_dict(
     input_node: models.ThresholdNode, analysis: dict[str, typing.Any]
 ) -> dict[str, typing.Any]:
-    return dict(
-        list(
-            map(
-                lambda x: (x[1:], variable.get_variable_value(analysis, x)),
-                variable.get_variable_names(input_node.rule),
-            )
-        )
-    )
-
-
-def does_node_pass(input_node: models.ThresholdNode, analysis: dict[str, typing.Any]) -> bool:
-    """
-    Evaluates the PASS/FAIL status of a QC node.
-
-    Args:
-      input_node: An s-expression list in the form of [operator, arg1, arg2, ...].
-
-      analysis (dict): A dictionary containing to the variables referenced in the
-      given QC node
-
-    Yields:
-      True if the node passes QC, False if it fails QC.
-    """
-    return node.evaluate_rule(node.eval_variables(analysis, input_node.rule))
+    return {
+        name[1:]: variable.resolve(analysis, name)
+        for name in variable.get_variable_names(input_node.rule)
+    }
 
 
 def create_qc_message(
@@ -58,7 +39,18 @@ def create_qc_message(
 def build_qc_node(
     input_node: models.ThresholdNode, analysis: dict[str, typing.Any]
 ) -> dict[str, typing.Any]:
-    is_pass = does_node_pass(input_node, analysis)
+    """Evaluate one threshold, returning its pass/fail state and explanation.
+
+    Raises:
+        AutoQCError: If the rule cannot be evaluated (e.g. it compares a number
+            to text). The rule's name and fail code are added for context.
+    """
+    try:
+        trace = node.evaluate(input_node.rule, analysis)
+    except AutoQCError as err:
+        raise AutoQCError(f"Rule '{input_node.name}' ({input_node.fail_code}): {err}") from err
+
+    is_pass = bool(trace.result)
     variables = create_variable_dict(input_node, analysis)
 
     return {
@@ -68,4 +60,5 @@ def build_qc_node(
         "fail_code": input_node.fail_code,
         "tags": input_node.tags or [],
         "message": create_qc_message(is_pass, input_node, variables),
+        "explain": trace.to_dict(),
     }

--- a/auto_qc/explain.py
+++ b/auto_qc/explain.py
@@ -1,9 +1,9 @@
 """Render a rich tree explaining how each QC rule was evaluated.
 
 The standard ``PASS`` / ``FAIL: <code>`` output answers *whether* a sample
-passed. ``--explain`` answers *why*: it walks the s-expression of every rule,
-resolves each metric pointer to its value, and prints the evaluation tree with
-the passing and failing branches marked, so a failure is self-explanatory.
+passed. ``--explain`` answers *why*: it renders the :class:`~auto_qc.node.Trace`
+produced by the one evaluator, resolving each metric pointer to its value and
+marking the passing and failing branches, so a failure is self-explanatory.
 """
 
 import typing
@@ -12,12 +12,7 @@ from rich.console import Console
 from rich.markup import escape
 from rich.tree import Tree
 
-from auto_qc import models, node, variable
-
-
-def _is_rule(expr: typing.Any) -> bool:
-    """Is the expression a nested rule (a list led by a known operator)?"""
-    return isinstance(expr, list) and len(expr) > 0 and node.is_operator(expr[0])
+from auto_qc import models, node
 
 
 def _mark(value: typing.Any) -> str:
@@ -38,35 +33,30 @@ def _operator_label(op: str, result: typing.Any) -> str:
     )
 
 
-def _leaf(expr: typing.Any, data: dict[str, typing.Any]) -> tuple[typing.Any, Tree]:
-    if variable.is_variable(expr):
-        value = variable.get_variable_value(data, expr)
-        label = f"[cyan]{escape(expr)}[/cyan] [dim]=[/dim] [yellow]{escape(repr(value))}[/yellow]"
-        return value, Tree(label)
-    return expr, Tree(f"[yellow]{escape(repr(expr))}[/yellow]")
+def _render_trace(trace: node.Trace) -> Tree:
+    """Turn a :class:`~auto_qc.node.Trace` into a rich tree."""
+    if trace.kind == "variable":
+        label = (
+            f"[cyan]{escape(str(trace.variable))}[/cyan] [dim]=[/dim] "
+            f"[yellow]{escape(repr(trace.result))}[/yellow]"
+        )
+        return Tree(label)
 
+    if trace.kind in ("literal", "list"):
+        return Tree(f"[yellow]{escape(repr(trace.result))}[/yellow]")
 
-def _evaluate(expr: typing.Any, data: dict[str, typing.Any]) -> tuple[typing.Any, Tree]:
-    """Evaluate an s-expression, returning its value and a tree explaining it."""
-    if not _is_rule(expr):
-        return _leaf(expr, data)
-
-    op = expr[0]
-    children = [_evaluate(arg, data) for arg in expr[1:]]
-    result = node.OPERATORS[op.lower()](*[value for value, _ in children])
-
-    tree = Tree(_operator_label(op, result))
-    for _, child_tree in children:
-        tree.add(child_tree)
-    return result, tree
+    tree = Tree(_operator_label(trace.operator or "", trace.result))
+    for child in trace.children:
+        tree.add(_render_trace(child))
+    return tree
 
 
 def render(state: models.AutoQC, console: Console) -> None:
     """Print an evaluation tree for every threshold in the QC document."""
     for threshold in state.thresholds:
-        result, rule_tree = _evaluate(threshold.rule, state.data)
-        status = "[bold green]PASS[/bold green]" if result else "[bold red]FAIL[/bold red]"
+        trace = node.evaluate(threshold.rule, state.data)
+        status = "[bold green]PASS[/bold green]" if trace.result else "[bold red]FAIL[/bold red]"
         root = Tree(f"{status} {escape(threshold.name)} [dim]({escape(threshold.fail_code)})[/dim]")
-        root.add(rule_tree)
+        root.add(_render_trace(trace))
         console.print(root)
         console.print()

--- a/auto_qc/main.py
+++ b/auto_qc/main.py
@@ -1,4 +1,5 @@
 import sys
+import typing
 from importlib import resources
 
 import click
@@ -12,10 +13,27 @@ from auto_qc import explain as explain_view
 from auto_qc.evaluate import qc
 
 
+def _load_document(path: str) -> typing.Any:
+    """Parse a YAML/JSON document from a path, or from stdin when ``path`` is ``-``."""
+    if path == "-":
+        return yaml.safe_load(sys.stdin.read())
+    with open(path) as handle:
+        return yaml.safe_load(handle)
+
+
 @click.command()
-@click.option("--data", "-d", help="Path to data YAML/JSON.", type=click.Path(exists=True))
+@click.version_option(auto_qc.__version__, "-V", "--version", prog_name="auto-qc")
 @click.option(
-    "--thresholds", "-t", help="Path to thresholds YAML/JSON.", type=click.Path(exists=True)
+    "--data",
+    "-d",
+    help="Path to data YAML/JSON, or '-' to read from stdin.",
+    type=click.Path(exists=True, allow_dash=True),
+)
+@click.option(
+    "--thresholds",
+    "-t",
+    help="Path to thresholds YAML/JSON, or '-' to read from stdin.",
+    type=click.Path(exists=True, allow_dash=True),
 )
 @click.option(
     "--json-output",
@@ -70,18 +88,20 @@ def cli(
         stderr.print(f"[red]Error[/red]: missing required flags: {', '.join(missing_flags)}")
         exit(1)
 
+    if data == "-" and thresholds == "-":
+        stderr.print("[red]Error[/red]: only one of --data / --thresholds can read from stdin.")
+        exit(1)
+
     try:
-        with open(thresholds) as threshold, open(data) as analysis:
-            state = core.build(yaml.safe_load(threshold), yaml.safe_load(analysis))
+        state = core.build(_load_document(thresholds), _load_document(data))
+        evaluation = qc.evaluate(state)
+        if explain:
+            explain_view.render(state, stdout)
     except auto_qc.exception.AutoQCError as err:
         stderr.print(f"[red]Errors[/red]:\n{err}")
         sys.exit(1)
 
-    evaluation = qc.evaluate(state)
-
-    if explain:
-        explain_view.render(state, stdout)
-    else:
+    if not explain:
         print(evaluation.to_evaluation_string(json_output))
 
     sys.exit(0 if evaluation.is_pass else 1)

--- a/auto_qc/node.py
+++ b/auto_qc/node.py
@@ -1,93 +1,174 @@
+"""The s-expression engine: one evaluator for ``run``, ``--explain`` and tests.
+
+A rule is a nested list (an s-expression). A list whose first element is a known
+operator is an *application*; any other list is a *literal list* (e.g. the set
+of allowed values for ``is_in``). Strings beginning with ``:`` are pointers into
+the data document.
+
+:func:`evaluate` is the single source of truth: it resolves pointers, applies
+operators, and returns a :class:`Trace` carrying both the result and a tree that
+explains how it was reached. ``--explain`` renders that tree; the JSON output
+serialises it; the pass/fail logic reads ``trace.result``. There is no second
+evaluator to drift out of sync.
+"""
+
+import dataclasses
 import functools
 import operator
+import re
 import typing
 
 from auto_qc import variable
-from auto_qc.util import functional
+from auto_qc.evaluate import exception
 
-OPERATORS: dict[str, typing.Callable[..., typing.Any]] = {
-    "greater_than": operator.gt,
-    "greater_equal_than": operator.ge,
-    "less_than": operator.lt,
-    "less_equal_than": operator.le,
-    "equals": operator.eq,
-    "not_equals": operator.ne,
-    "and": lambda *args: all(args),
-    "or": lambda *args: any(args),
-    "not": lambda x: not x,
-    "is_in": lambda x, y: x in y,
-    "is_not_in": lambda x, y: x not in y,
-    "list": lambda *args: list(args),
+
+@dataclasses.dataclass(frozen=True)
+class Operator:
+    """An operator's implementation plus the metadata used to validate it."""
+
+    func: typing.Callable[..., typing.Any]
+    min_args: int
+    max_args: int | None  # ``None`` means unbounded (variadic).
+    kind: str  # Used to phrase type errors, e.g. "compare" / "do arithmetic on".
+
+
+def _product(values: typing.Iterable[float]) -> float:
+    return functools.reduce(operator.mul, values, 1)
+
+
+OPERATORS: dict[str, Operator] = {
+    # Comparisons.
+    "greater_than": Operator(operator.gt, 2, 2, "compare"),
+    "greater_equal_than": Operator(operator.ge, 2, 2, "compare"),
+    "less_than": Operator(operator.lt, 2, 2, "compare"),
+    "less_equal_than": Operator(operator.le, 2, 2, "compare"),
+    "equals": Operator(operator.eq, 2, 2, "compare"),
+    "not_equals": Operator(operator.ne, 2, 2, "compare"),
+    "between": Operator(lambda v, lo, hi: lo <= v <= hi, 3, 3, "compare"),
+    # Boolean combinators. Their arguments are themselves rules.
+    "and": Operator(lambda *args: all(args), 1, None, "combine"),
+    "or": Operator(lambda *args: any(args), 1, None, "combine"),
+    "not": Operator(lambda x: not x, 1, 1, "combine"),
+    # Membership.
+    "is_in": Operator(lambda x, y: x in y, 2, 2, "test membership of"),
+    "is_not_in": Operator(lambda x, y: x not in y, 2, 2, "test membership of"),
+    "contains": Operator(lambda x, y: y in x, 2, 2, "test membership of"),
+    "list": Operator(lambda *args: list(args), 0, None, "build a list from"),
+    # Arithmetic, for rules over derived values like ratios.
+    "add": Operator(lambda *args: sum(args), 2, None, "do arithmetic on"),
+    "subtract": Operator(lambda a, b: a - b, 2, 2, "do arithmetic on"),
+    "multiply": Operator(lambda *args: _product(args), 2, None, "do arithmetic on"),
+    "divide": Operator(lambda a, b: a / b, 2, 2, "do arithmetic on"),
+    # String / collection predicates.
+    "matches": Operator(lambda s, pattern: re.search(pattern, s) is not None, 2, 2, "match"),
+    "starts_with": Operator(lambda s, prefix: s.startswith(prefix), 2, 2, "match"),
+    "ends_with": Operator(lambda s, suffix: s.endswith(suffix), 2, 2, "match"),
+    "length": Operator(lambda x: len(x), 1, 1, "measure the length of"),
 }
 
-
-def is_operator(v: typing.Any) -> bool:
-    return isinstance(v, str) and v.lower() in OPERATORS
-
-
-def has_doc_dict(qc_node: list[typing.Any]) -> bool:
-    return isinstance(qc_node[0], dict)
+# Operators whose arguments are themselves boolean rules rather than values.
+RULE_POSITION_OPERATORS = {"and", "or", "not"}
 
 
-def get_all_operators(qc_node: list[typing.Any]) -> list[typing.Any]:
-    """
-    Returns all operators listed in a QC node
-    """
-
-    def _walk_node(n: list[typing.Any]) -> list[typing.Any]:
-        operator_, rest = n[0], n[1:]
-        return [operator_, *f(rest)]
-
-    f = functools.partial(map, functional.recursive_apply(_walk_node, functional.empty_list))
-
-    return functional.flatten(_walk_node(qc_node))
+def is_operator(value: typing.Any) -> bool:
+    return isinstance(value, str) and value.lower() in OPERATORS
 
 
-def eval_variables(analyses: dict[str, typing.Any], rule: list[typing.Any]) -> list[typing.Any]:
-    """
-    Replace all variables in a node s-expression with their referenced literal
-    value.
+def is_application(expr: typing.Any) -> bool:
+    """Is ``expr`` a rule application (a list led by a known operator)?"""
+    return isinstance(expr, list) and len(expr) > 0 and is_operator(expr[0])
 
-    Args:
-      analyses: A dictionary corresponding to the values referenced in the
-      given s-expression.
-      rule: An s-expression list in the form of [operator, arg1, arg2, ...].
 
-    Yields:
-      A node expression with referenced values replaced with their literal values.
+def _describe(value: typing.Any) -> str:
+    """A short, human word for a value's type, for error messages."""
+    if value is None:
+        return "missing (null)"
+    if isinstance(value, bool):
+        return "true/false"
+    if isinstance(value, (int, float)):
+        return f"the number {value!r}"
+    if isinstance(value, str):
+        return f"the text {value!r}"
+    if isinstance(value, list):
+        return f"the list {value!r}"
+    return repr(value)
 
-    Examples:
-      >>> eval_variables({a: 1}, [>, :a, 2])
-      [>, 1, 2]
-    """
 
-    def _eval(n: typing.Any) -> typing.Any:
-        if variable.is_variable(n):
-            return variable.get_variable_value(analyses, n)
-        else:
-            return n
+def arity_message(op_name: str, op: Operator, given: int) -> str:
+    """Phrase a wrong-number-of-arguments error."""
+    if op.max_args == op.min_args:
+        expected = f"exactly {op.min_args} argument{'s' if op.min_args != 1 else ''}"
+    elif op.max_args is None:
+        expected = f"at least {op.min_args} argument{'s' if op.min_args != 1 else ''}"
+    else:
+        expected = f"between {op.min_args} and {op.max_args} arguments"
+    return f"Operator '{op_name.lower()}' takes {expected} but got {given}."
 
-    return list(
-        map(functional.recursive_apply(functools.partial(eval_variables, analyses), _eval), rule)
+
+def _type_message(op_name: str, op: Operator, args: list[typing.Any]) -> str:
+    described = " and ".join(_describe(a) for a in args)
+    return (
+        f"Operator '{op_name.lower()}' could not {op.kind} {described}. "
+        f"Check that the rule and the data have compatible types."
     )
 
 
-def evaluate_rule(node: list[typing.Any]) -> typing.Any:
+def _apply(op_name: str, op: Operator, args: list[typing.Any]) -> typing.Any:
+    given = len(args)
+    if given < op.min_args or (op.max_args is not None and given > op.max_args):
+        raise exception.EvaluationError(arity_message(op_name, op, given))
+    try:
+        return op.func(*args)
+    except ZeroDivisionError:
+        raise exception.EvaluationError(f"Operator '{op_name.lower()}' divided by zero.") from None
+    except (TypeError, AttributeError):
+        raise exception.EvaluationError(_type_message(op_name, op, args)) from None
+
+
+@dataclasses.dataclass
+class Trace:
+    """The result of evaluating an expression, plus an explanation tree."""
+
+    result: typing.Any
+    kind: str  # "operator" | "variable" | "literal" | "list"
+    operator: str | None = None
+    variable: str | None = None
+    children: list["Trace"] = dataclasses.field(default_factory=list)
+
+    def to_dict(self) -> dict[str, typing.Any]:
+        """A JSON-serialisable view of this trace, for ``--json-output``."""
+        if self.kind == "variable":
+            return {"variable": self.variable, "value": self.result}
+        if self.kind == "literal":
+            return {"literal": self.result}
+        if self.kind == "list":
+            return {"list": [child.to_dict() for child in self.children]}
+        return {
+            "operator": (self.operator or "").lower(),
+            "result": self.result,
+            "args": [child.to_dict() for child in self.children],
+        }
+
+
+def evaluate(expr: typing.Any, data: dict[str, typing.Any]) -> Trace:
+    """Evaluate an s-expression against ``data``, returning a :class:`Trace`.
+
+    Raises:
+        EvaluationError: If an operator is applied to incompatible types or the
+            wrong number of arguments.
     """
-    Evaluate an s-expression by applying the operator to the rest of the arguments.
+    if variable.is_variable(expr):
+        return Trace(result=variable.resolve(data, expr), kind="variable", variable=expr)
 
-    Args:
-      node (list): An s-expression list in the form of [operator, arg1, arg2, ...]
+    if is_application(expr):
+        op_name = expr[0]
+        op = OPERATORS[op_name.lower()]
+        children = [evaluate(arg, data) for arg in expr[1:]]
+        result = _apply(op_name, op, [child.result for child in children])
+        return Trace(result=result, kind="operator", operator=op_name, children=children)
 
-    Yields:
-      The result of "applying" the operator to the arugments. Will evaluate
-      recursively if any of the args are a list.
+    if isinstance(expr, list):
+        children = [evaluate(element, data) for element in expr]
+        return Trace(result=[child.result for child in children], kind="list", children=children)
 
-    Examples:
-      >>> evaluate_rule([>, 0, 1])
-      FALSE
-    """
-    args = list(map(functional.recursive_apply(evaluate_rule), node[1:]))
-    op = node[0]
-    qc_func = OPERATORS[op.lower() if isinstance(op, str) else op]
-    return qc_func(*args)
+    return Trace(result=expr, kind="literal")

--- a/auto_qc/variable.py
+++ b/auto_qc/variable.py
@@ -26,6 +26,16 @@ def is_variable_path_valid(data: dict[str, typing.Any], path: str) -> bool:
     return True
 
 
+def resolve(data: dict[str, typing.Any], path: str) -> typing.Any:
+    """Return the raw value at ``path``, or ``None`` if any key is missing.
+
+    Unlike :func:`get_variable_value`, lists are returned as-is rather than
+    wrapped in a ``list`` s-expression, so the engine can use a referenced list
+    directly (e.g. as the right-hand side of ``is_in``).
+    """
+    return functional.get_in(data, path[1:].split("/"))
+
+
 def get_variable_value(data: dict[str, typing.Any], path: str) -> typing.Any:
     """Get variable's value by traversing its path into the data file.
 

--- a/features/errors.feature
+++ b/features/errors.feature
@@ -122,3 +122,57 @@ Scenario: A QC entry is missing a failure code
     thresholds.0.fail_code
     """
   And the exit code should be 1
+
+Scenario: A rule compares incompatible types
+  Given I create the file "analysis.yml" with the contents:
+   """
+   coverage:
+     mean_depth: not a number
+   """
+  And I create the file "threshold.yml" with the contents:
+   """
+   version: 3.0.0
+   thresholds:
+   - name: Coverage too low
+     fail_code: LOW_COVERAGE
+     rule: ["greater_than", ":coverage/mean_depth", 30]
+   """
+  When I run the command "auto-qc" with the arguments:
+    | key              | value         |
+    | --data           | analysis.yml  |
+    | --thresholds     | threshold.yml |
+  Then the standard out should be empty
+  And the standard error should contain:
+    """
+    Rule 'Coverage too low' (LOW_COVERAGE)
+    """
+  And the standard error should contain:
+    """
+    could not compare
+    """
+  And the exit code should be 1
+
+Scenario: An operator is given the wrong number of arguments
+  Given I create the file "analysis.yml" with the contents:
+   """
+   sample:
+     is_control: false
+   """
+  And I create the file "threshold.yml" with the contents:
+   """
+   version: 3.0.0
+   thresholds:
+   - name: Not a control
+     fail_code: CONTROL
+     rule: ["not", ":sample/is_control", true]
+   """
+  When I run the command "auto-qc" with the arguments:
+    | key              | value         |
+    | --data           | analysis.yml  |
+    | --thresholds     | threshold.yml |
+  Then the standard out should be empty
+  And the standard error should contain:
+    """
+    Operator 'not' takes exactly 1 argument but got 2.
+    """
+  And the exit code should be 1

--- a/features/outputs.feature
+++ b/features/outputs.feature
@@ -36,6 +36,14 @@ Scenario Outline: Generating JSON formatted output
         "pass": <pass>,
         "qc": [
             {
+                "explain": {
+                    "operator": "greater_than",
+                    "result": <pass>,
+                    "args": [
+                        {"variable": ":value", "value": 2},
+                        {"literal": <literal>}
+                    ]
+                },
                 "fail_code": "ERR00001",
                 "message": "<msg>",
                 "name": "example test",

--- a/test/test_error_handling.py
+++ b/test/test_error_handling.py
@@ -2,7 +2,7 @@ import typing
 
 import pytest
 
-from auto_qc import exception, models, version
+from auto_qc import core, exception, models, version
 from auto_qc.evaluate import error
 
 
@@ -57,3 +57,43 @@ def test_check_operators_with_unknown_nested_operator():
     with pytest.raises(exception.AutoQCError):
         auto_qc_eval = _create_auto_qc({"ref": {"metric_1": 2}}, ["and", ["or", ["unknown", 2, 1]]])
         error.check_operators(auto_qc_eval)
+
+
+def test_check_operators_allows_literal_list_in_value_position():
+    """A plain list as an ``is_in`` set is data, not an unknown operator."""
+    auto_qc_eval = _create_auto_qc(
+        {"sample": {"protocol": "PCR-free"}},
+        ["is_in", ":sample/protocol", ["Low Input DNA", "PCR-free"]],
+    )
+    error.check_operators(auto_qc_eval)  # Should not raise.
+
+
+def test_check_arity_flags_too_many_arguments():
+    """``not`` takes a single argument; two should be reported up front."""
+    auto_qc_eval = _create_auto_qc({"ref": {"metric_1": 2}}, ["not", True, False])
+    with pytest.raises(exception.AutoQCError, match="exactly 1 argument"):
+        error.check_arity(auto_qc_eval)
+
+
+def test_check_arity_flags_too_few_arguments():
+    """A comparison needs two arguments."""
+    auto_qc_eval = _create_auto_qc({"ref": {"metric_1": 2}}, ["greater_than", ":ref/metric_1"])
+    with pytest.raises(exception.AutoQCError, match="exactly 2 arguments"):
+        error.check_arity(auto_qc_eval)
+
+
+def test_check_arity_accepts_valid_rules():
+    auto_qc_eval = _create_auto_qc({"ref": {"metric_1": 2}}, ["greater_than", ":ref/metric_1", 1])
+    error.check_arity(auto_qc_eval)  # Should not raise.
+
+
+def test_type_mismatch_surfaces_as_autoqc_error_with_rule_name():
+    """Comparing text to a number reports cleanly instead of crashing."""
+    thresholds = {
+        "version": version.__version__,
+        "thresholds": [
+            {"name": "Coverage too low", "fail_code": "LOW", "rule": ["greater_than", ":a", 3]}
+        ],
+    }
+    with pytest.raises(exception.AutoQCError, match="Coverage too low"):
+        core.run(thresholds, {"a": "not a number"})

--- a/test/test_evaluate.py
+++ b/test/test_evaluate.py
@@ -19,6 +19,11 @@ def test_build_passing_qc_node_with_two_literals():
         "tags": [],
         "fail_code": "ERR01",
         "message": "passes",
+        "explain": {
+            "operator": "greater_than",
+            "result": True,
+            "args": [{"literal": 2}, {"literal": 1}],
+        },
     }
     assert qc.build_qc_node(threshold_node, {}) == expected
 
@@ -40,6 +45,11 @@ def test_build_failing_qc_node_with_literal_and_variable():
         "tags": [],
         "fail_code": "ERR01",
         "message": "fails",
+        "explain": {
+            "operator": "less_than",
+            "result": False,
+            "args": [{"variable": ":ref/metric_1", "value": 2}, {"literal": 1}],
+        },
     }
     assert qc.build_qc_node(threshold_node, a) == expected
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,0 +1,79 @@
+import json
+
+from click.testing import CliRunner
+
+import auto_qc
+from auto_qc.main import cli
+
+THRESHOLDS = """
+version: 3.0.0
+thresholds:
+  - name: Coverage too low
+    fail_code: LOW_COVERAGE
+    rule: ["greater_than", ":coverage/mean_depth", 30]
+"""
+
+
+def _write(tmp_path, name, body):
+    path = tmp_path / name
+    path.write_text(body)
+    return str(path)
+
+
+def test_version_flag_prints_version():
+    result = CliRunner().invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert auto_qc.__version__ in result.output
+    assert "auto-qc" in result.output
+
+
+def test_missing_flags_are_reported():
+    result = CliRunner().invoke(cli, [])
+    assert result.exit_code == 1
+    assert "missing required flags" in result.stderr
+
+
+def test_reads_data_from_stdin():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        thresholds = _write_cwd("thresholds.yml", THRESHOLDS)
+        result = runner.invoke(
+            cli,
+            ["-t", thresholds, "-d", "-"],
+            input='{"coverage": {"mean_depth": 40}}',
+        )
+    assert result.exit_code == 0
+    assert "PASS" in result.output
+
+
+def _write_cwd(name, body):
+    with open(name, "w") as handle:
+        handle.write(body)
+    return name
+
+
+def test_both_stdin_is_rejected():
+    result = CliRunner().invoke(cli, ["-t", "-", "-d", "-"], input="{}")
+    assert result.exit_code == 1
+    assert "stdin" in result.stderr
+
+
+def test_type_mismatch_reports_rule_name_not_traceback(tmp_path):
+    thresholds = _write(tmp_path, "t.yml", THRESHOLDS)
+    data = _write(tmp_path, "d.yml", "coverage:\n  mean_depth: not-a-number\n")
+    result = CliRunner().invoke(cli, ["-t", thresholds, "-d", data])
+    assert result.exit_code == 1
+    assert "Coverage too low" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_json_output_includes_machine_readable_explain(tmp_path):
+    thresholds = _write(tmp_path, "t.yml", THRESHOLDS)
+    data = _write(tmp_path, "d.yml", "coverage:\n  mean_depth: 18.6\n")
+    result = CliRunner().invoke(cli, ["-t", thresholds, "-d", data, "--json-output"])
+    assert result.exit_code == 1
+    report = json.loads(result.output)
+    explain = report["qc"][0]["explain"]
+    assert explain["operator"] == "greater_than"
+    assert explain["result"] is False
+    assert {"variable": ":coverage/mean_depth", "value": 18.6} in explain["args"]

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -1,20 +1,25 @@
+import pytest
+
 from auto_qc import node
+from auto_qc.evaluate import exception
+
+
+def _eval(expr, data=None):
+    return node.evaluate(expr, data or {}).result
 
 
 def test_eval_greater_than_with_two_literals():
-    n = ["greater_than", 2, 1]
-    assert node.evaluate_rule(n)
+    assert _eval(["greater_than", 2, 1])
 
 
 def test_eval_less_than_with_two_literals():
-    n = ["less_than", 2, 1]
-    assert not node.evaluate_rule(n)
+    assert not _eval(["less_than", 2, 1])
 
 
 def test_operators_are_case_insensitive():
     assert node.is_operator("OR")
     assert node.is_operator("Greater_Than")
-    assert node.evaluate_rule(["AND", ["GREATER_THAN", 2, 1], ["greater_than", 3, 1]])
+    assert _eval(["AND", ["GREATER_THAN", 2, 1], ["greater_than", 3, 1]])
 
 
 def test_non_string_is_not_an_operator():
@@ -22,58 +27,89 @@ def test_non_string_is_not_an_operator():
 
 
 def test_eval_true_with_nested_lists():
-    n = ["and", ["greater_than", 2, 1], ["greater_than", 2, 1]]
-    assert node.evaluate_rule(n)
+    assert _eval(["and", ["greater_than", 2, 1], ["greater_than", 2, 1]])
 
 
 def test_eval_false_with_nested_lists():
-    n = ["and", ["greater_than", 1, 2], ["greater_than", 1, 2]]
-    assert not node.evaluate_rule(n)
+    assert not _eval(["and", ["greater_than", 1, 2], ["greater_than", 1, 2]])
 
 
-def test_eval_with_list():
-    n = ["list", 2, 1]
-    assert [2, 1] == node.evaluate_rule(n)
+def test_eval_with_list_operator():
+    assert _eval(["list", 2, 1]) == [2, 1]
 
 
 def test_eval_with_in():
-    n = ["is_in", 2, ["list", 2, 1]]
-    assert node.evaluate_rule(n)
+    assert _eval(["is_in", 2, ["list", 2, 1]])
 
 
 def test_eval_with_is_not_in():
-    n = ["is_not_in", 2, ["list", 2, 1]]
-    assert not node.evaluate_rule(n)
+    assert not _eval(["is_not_in", 2, ["list", 2, 1]])
 
 
-def test_eval_variable_with_literal_and_variable():
-    n = ["less_than", ":ref/metric_1", 1]
-    a = {"ref": {"metric_1": 2}}
-    assert ["less_than", 2, 1] == node.eval_variables(a, n)
+def test_is_in_accepts_a_plain_literal_list():
+    """A list not led by an operator is a literal list, no ``list`` keyword needed."""
+    assert _eval(["is_in", "PCR-free", ["Low Input DNA", "PCR-free"]])
+    assert not _eval(["is_in", "Standard DNA", ["Low Input DNA", "PCR-free"]])
 
 
-def test_eval_variable_with_nested_list():
-    n = ["and", ["less_than", ":ref/metric_1", 1], ["less_than", ":ref/metric_1", 1]]
-    a = {"ref": {"metric_1": 2}}
-
-    assert ["and", ["less_than", 2, 1], ["less_than", 2, 1]] == node.eval_variables(a, n)
+def test_eval_resolves_variables():
+    assert not _eval(["less_than", ":ref/metric_1", 1], {"ref": {"metric_1": 2}})
 
 
-def test_eval_with_doc_string():
-    n = ["greater_than", 2, 1]
-    assert node.evaluate_rule(n)
+def test_eval_resolves_variables_in_nested_lists():
+    data = {"ref": {"metric_1": 2}}
+    assert not _eval(["and", ["less_than", ":ref/metric_1", 1], ["greater_than", 0, 1]], data)
 
 
-def test_get_all_operators_with_single_threshold():
-    n = ["less_than", 2, 1]
-    assert node.get_all_operators(n) == ["less_than"]
+def test_between_is_inclusive():
+    assert _eval(["between", 5, 1, 10])
+    assert _eval(["between", 1, 1, 10])
+    assert not _eval(["between", 11, 1, 10])
 
 
-def test_get_all_operators_with_nested_threshold():
-    n = ["and", ["or", ["less_than", 2, 1]]]
-    assert node.get_all_operators(n) == ["and", "or", "less_than"]
+def test_arithmetic_feeds_a_comparison():
+    data = {"reads": {"mapped": 95, "total": 100}}
+    assert _eval(["greater_than", ["divide", ":reads/mapped", ":reads/total"], 0.9], data)
+    assert _eval(["add", 1, 2, 3]) == 6
+    assert _eval(["multiply", 2, 3, 4]) == 24
+    assert _eval(["subtract", 10, 3]) == 7
 
 
-def test_get_all_operators_with_doc_string():
-    n = ["less_than", 2, 1]
-    assert node.get_all_operators(n) == ["less_than"]
+def test_string_predicates():
+    data = {"sample": {"id": "SRX-4521"}}
+    assert _eval(["matches", ":sample/id", "^SRX-"], data)
+    assert _eval(["starts_with", ":sample/id", "SRX"], data)
+    assert _eval(["ends_with", ":sample/id", "4521"], data)
+    assert _eval(["length", ":sample/id"], data) == 8
+
+
+def test_type_mismatch_raises_evaluation_error_not_typeerror():
+    with pytest.raises(exception.EvaluationError):
+        _eval(["greater_than", "text", 3])
+
+
+def test_comparing_missing_value_raises_evaluation_error():
+    with pytest.raises(exception.EvaluationError):
+        _eval(["greater_than", ":missing", 3], {})
+
+
+def test_divide_by_zero_raises_evaluation_error():
+    with pytest.raises(exception.EvaluationError, match="divided by zero"):
+        _eval(["divide", 1, 0])
+
+
+def test_wrong_arity_raises_evaluation_error():
+    with pytest.raises(exception.EvaluationError):
+        _eval(["not", True, False])
+
+
+def test_trace_to_dict_describes_the_evaluation():
+    trace = node.evaluate(["greater_than", ":depth", 30], {"depth": 18.6})
+    assert trace.to_dict() == {
+        "operator": "greater_than",
+        "result": False,
+        "args": [
+            {"variable": ":depth", "value": 18.6},
+            {"literal": 30},
+        ],
+    }


### PR DESCRIPTION
## Summary

A review of the v3.0.0 branch surfaced one load-bearing crack and several gaps that hold the tool back from "heavily used." This PR fixes them. It makes the s-expression engine **safe** (no more raw tracebacks), **single** (one evaluator, not two), and **more expressive**, plus the CLI polish that makes it pipeline-friendly.

All work targets `v3.0.0` (not `master`).

## Engine safety

- **Rules that can't be evaluated now report cleanly instead of crashing.** Type mismatches (comparing a number to text, or to a missing/`null` metric) and operators given the wrong number of arguments previously dumped a Python traceback — directly undercutting the "analysts own the rules, invalid input raises one `AutoQCError`" promise. They now raise a single `AutoQCError` naming the rule, e.g. `Rule 'Coverage too low' (LOW_COVERAGE): Operator 'greater_than' could not compare the text 'x' and the number 30.` Argument counts are validated up front at build time.
- **One evaluator.** `node.evaluate` is now the single source of truth, returning a `Trace` that carries both the result and an explanation tree. `--explain` renders that tree and `--json-output` serialises it, removing the duplicate evaluator in `explain.py` that could silently drift from the pass/fail logic.

## More expressive rules

- New operators, all within the existing s-expression syntax: `between` (inclusive range); `add` / `subtract` / `multiply` / `divide` (arithmetic over derived values such as ratios — the biggest expressiveness gap); `matches` / `starts_with` / `ends_with` / `contains` (string & collection predicates); and `length`.
- `is_in` / `is_not_in` accept an **inline literal list** — no more `["list", ...]` wrapper for the common case.

## CLI delight

- `--data` / `--thresholds` accept `-` to **read from stdin**, so auto-qc drops into a shell pipeline without a temp file.
- Added `--version` / `-V`.
- `--json-output` now includes a **machine-readable `explain` tree** per rule (each operator with its result, each pointer resolved to its value), so a dashboard can show *why* a rule failed without re-running the tool.

## Tests & docs

- New `test/test_main.py` covers the CLI end-to-end (version, stdin, friendly type errors, JSON explain); `test_node.py` rewritten around the unified evaluator with coverage for arithmetic, ranges, string predicates, and every error path; new error-handling and feature scenarios for type/arity errors.
- README, MANUAL, and CHANGELOG updated.
- Full suite green: **57 unit tests, mypy, ruff (lint + format), 58 behave scenarios**, and the package builds.

## Notes for the reviewer

- The JSON output schema gains an `explain` key per rule (an addition to the unreleased 3.0.0 format). The `outputs.feature` expectation was updated to match.
- Internal helpers `node.eval_variables` / `evaluate_rule` / `get_all_operators` were removed in favour of `node.evaluate`; the public API (`run`, `build`, models) is unchanged.

https://claude.ai/code/session_01D8bcLGsW97nqkcA1Tc6o54

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8bcLGsW97nqkcA1Tc6o54)_