### PR TITLE
Add --margin: how close each comparison is to flipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+
+- A `--margin` / `-M` flag that reports, for every ordered numeric comparison in
+  a rule, how far the metric could move before the comparison flips — the slack
+  on a passing check or the shortfall on a failing one — and marks the tightest
+  comparison in each rule. This surfaces _how robustly_ a sample passed, which a
+  bare `PASS`/`FAIL` hides. Equality, string and membership tests are discrete
+  and have no margin, so they are skipped.
+
 ## 3.0.0 - 2026-06-01
 
 This is a major release that ports auto-qc to Python 3, modernises the packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
   comparison in each rule. This surfaces _how robustly_ a sample passed, which a
   bare `PASS`/`FAIL` hides. Equality, string and membership tests are discrete
   and have no margin, so they are skipped.
+- The same margin is included on every ordered comparison node in the
+  `--json-output` `explain` tree (a `margin` key alongside `operator`, `result`
+  and `args`), so the margins of a whole cohort of samples can be aggregated —
+  per rule — into a threshold-sensitivity dataset.
 
 ## 3.0.0 - 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -188,12 +188,17 @@ without re-running the tool:
         "args": [
           { "variable": ":coverage/mean_depth", "value": 18.6 },
           { "literal": 30 }
-        ]
+        ],
+        "margin": -11.4
       }
     }
   ]
 }
 ```
+
+Each ordered numeric comparison also carries a `margin`: the signed distance to
+the boundary, negative here because the depth of `18.6` falls `11.4` short of
+the cutoff of `30`. See [Margins](#margins) for what this is good for.
 
 ## Margins
 
@@ -219,6 +224,25 @@ ordered comparisons (`greater_than`, `greater_equal_than`, `less_than`,
 `less_equal_than`, `between`) have a continuous margin; equality, string and
 membership tests are discrete and are skipped. Like `--explain`, `--margin`
 still exits `0` on pass and `1` on fail, so it slots into the same pipeline.
+
+The same `margin` value is attached to every ordered comparison in the
+`--json-output` `explain` tree, which is what makes it useful at scale. Running
+a cohort of samples and collecting the margins turns a pile of pass/fail
+verdicts into a sensitivity dataset. Aggregate **per rule** (the slack is in
+each metric's own units, so pooling across different rules is meaningless), and
+the interesting signal is the tail near zero, not the mean:
+
+- **How bunched is the cohort against a cutoff?** Many samples with a slack near
+  zero means a small protocol change or instrument drift would flip a lot of
+  verdicts at once — a fragile gate the headline pass-rate hides.
+- **What would moving a threshold do?** Because the slack _is_ the distance to
+  the boundary, counting the samples whose slack falls between, say, `-2` and
+  `0` tells you exactly how many currently-failing samples a two-unit relaxation
+  would reclaim — a what-if curve for free, without re-running anything.
+
+For a rule that is a single comparison the slack is exactly the verdict's
+distance to flipping; for a compound `and`/`or` rule it is reported per
+comparison, so aggregate those at the comparison level.
 
 ## Python API
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ thresholds:
 - `-e`, `--explain`: Print a tree explaining how every rule was evaluated, with
   each metric pointer resolved to its value and the passing/failing branches
   marked.
+- `-M`, `--margin`: For every numeric comparison, print how far the metric could
+  move before the comparison flips — the _slack_ on a passing check, or how much
+  it falls short on a failing one (see [Margins](#margins)).
 - `-T`, `--test` <SUITE_FILE>: Run a suite of test cases against its thresholds
   file (see [Testing your rules](#testing-your-rules)).
 - `-m`, `--manual`: Print the full manual and exit.
@@ -191,6 +194,31 @@ without re-running the tool:
   ]
 }
 ```
+
+## Margins
+
+`PASS`/`FAIL` tells you _whether_ a sample cleared the rules; `--margin` tells
+you _how robustly_. For every ordered numeric comparison it reports the
+**slack** — the distance the metric could move before that comparison flips:
+
+```console
+$ auto-qc --data sample.yml --thresholds thresholds.yml --margin
+PASS Contamination too high (CONTAMINATION)
+    ✓ :contamination/percent_human=0.4 less_than 1 → slack 0.6 ← tightest
+
+FAIL Coverage below protocol threshold (LOW_COVERAGE)
+    ✗ :coverage/mean_depth=12.4 greater_than 15 → short by 2.6 ← tightest
+    ✗ :coverage/mean_depth=12.4 greater_than 30 → short by 17.6
+```
+
+A sample that clears a coverage cutoff by `0.1` is passing fragilely; one that
+clears it by `30` is passing comfortably — a difference the bare `PASS` hides
+but that matters when you are deciding whether to trust a whole batch. Within
+each rule the comparison closest to flipping is marked `← tightest`. Only the
+ordered comparisons (`greater_than`, `greater_equal_than`, `less_than`,
+`less_equal_than`, `between`) have a continuous margin; equality, string and
+membership tests are discrete and are skipped. Like `--explain`, `--margin`
+still exits `0` on pass and `1` on fail, so it slots into the same pipeline.
 
 ## Python API
 

--- a/auto_qc/MANUAL.md
+++ b/auto_qc/MANUAL.md
@@ -29,7 +29,10 @@ the check.
 - `-t`, `--thresholds` <FILE> — Path to the YAML/JSON file of rules, or `-` for
   standard input. Only one of `--data` / `--thresholds` may use stdin at once.
 - `-j`, `--json-output` — Print a detailed JSON report instead of PASS/FAIL.
-  Each rule includes an `explain` tree describing how it was evaluated.
+  Each rule includes an `explain` tree describing how it was evaluated, and
+  every ordered numeric comparison in it carries a `margin` (its signed distance
+  to the boundary), so a cohort of reports can be aggregated into a sensitivity
+  dataset.
 - `-e`, `--explain` — Print a tree explaining how every rule was evaluated.
 - `-M`, `--margin` — For every numeric comparison, print how far the metric
   could move before it flips: the slack on a passing check, or how much a

--- a/auto_qc/MANUAL.md
+++ b/auto_qc/MANUAL.md
@@ -31,6 +31,11 @@ the check.
 - `-j`, `--json-output` — Print a detailed JSON report instead of PASS/FAIL.
   Each rule includes an `explain` tree describing how it was evaluated.
 - `-e`, `--explain` — Print a tree explaining how every rule was evaluated.
+- `-M`, `--margin` — For every numeric comparison, print how far the metric
+  could move before it flips: the slack on a passing check, or how much a
+  failing one falls short. Only the ordered comparisons (`greater_than`,
+  `less_than`, `between`, ...) have a margin; equality and string tests are
+  skipped.
 - `-T`, `--test` <SUITE_FILE> — Run a suite of test cases against its thresholds
   file.
 - `-m`, `--manual` — Print this manual and exit.

--- a/auto_qc/main.py
+++ b/auto_qc/main.py
@@ -10,6 +10,7 @@ import auto_qc
 import auto_qc.exception
 from auto_qc import core, runner
 from auto_qc import explain as explain_view
+from auto_qc import margin as margin_view
 from auto_qc.evaluate import qc
 
 
@@ -50,6 +51,13 @@ def _load_document(path: str) -> typing.Any:
     default=False,
 )
 @click.option(
+    "--margin",
+    "-M",
+    help="Show how far each numeric comparison is from flipping its result.",
+    is_flag=True,
+    default=False,
+)
+@click.option(
     "--test",
     "-T",
     "test_suite",
@@ -58,7 +66,13 @@ def _load_document(path: str) -> typing.Any:
 )
 @click.option("--manual", "-m", help="Display the manual for auto-qc.", is_flag=True, default=False)
 def cli(
-    data: str, thresholds: str, json_output: bool, explain: bool, test_suite: str, manual: bool
+    data: str,
+    thresholds: str,
+    json_output: bool,
+    explain: bool,
+    margin: bool,
+    test_suite: str,
+    manual: bool,
 ) -> None:
 
     stdout = console.Console(width=100)
@@ -97,11 +111,13 @@ def cli(
         evaluation = qc.evaluate(state)
         if explain:
             explain_view.render(state, stdout)
+        if margin:
+            margin_view.render(state, stdout)
     except auto_qc.exception.AutoQCError as err:
         stderr.print(f"[red]Errors[/red]:\n{err}")
         sys.exit(1)
 
-    if not explain:
+    if not explain and not margin:
         print(evaluation.to_evaluation_string(json_output))
 
     sys.exit(0 if evaluation.is_pass else 1)

--- a/auto_qc/margin.py
+++ b/auto_qc/margin.py
@@ -23,17 +23,6 @@ from rich.markup import escape
 
 from auto_qc import models, node
 
-# Signed slack for each ordered comparison. The value is positive exactly when
-# the comparison holds, and its magnitude is the distance the compared value
-# must move to reach the boundary.
-_MARGIN: dict[str, typing.Callable[..., float]] = {
-    "greater_than": lambda value, bound: value - bound,
-    "greater_equal_than": lambda value, bound: value - bound,
-    "less_than": lambda value, bound: bound - value,
-    "less_equal_than": lambda value, bound: bound - value,
-    "between": lambda value, low, high: min(value - low, high - value),
-}
-
 
 @dataclasses.dataclass(frozen=True)
 class Comparison:
@@ -42,11 +31,6 @@ class Comparison:
     slack: float
     holds: bool
     description: str
-
-
-def _is_number(value: typing.Any) -> bool:
-    """Is ``value`` a real number we can measure a margin against (not a bool)?"""
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
 def _format_value(value: typing.Any) -> str:
@@ -83,12 +67,10 @@ def collect(trace: node.Trace) -> list[Comparison]:
     """Collect every measurable numeric comparison within ``trace``."""
     comparisons: list[Comparison] = []
     if trace.kind == "operator":
-        name = (trace.operator or "").lower()
-        values = [child.result for child in trace.children]
-        if name in _MARGIN and all(_is_number(value) for value in values):
+        if trace.margin is not None:
             comparisons.append(
                 Comparison(
-                    slack=float(_MARGIN[name](*values)),
+                    slack=trace.margin,
                     holds=bool(trace.result),
                     description=_describe(trace),
                 )

--- a/auto_qc/margin.py
+++ b/auto_qc/margin.py
@@ -1,0 +1,130 @@
+"""Report how close each numeric comparison is to flipping its result.
+
+The default output answers *whether* a sample passes. ``--margin`` answers *how
+robustly*: for every ordered numeric comparison in a rule it reports the
+**slack** — the distance the metric could move before that comparison flips. A
+coverage rule cleared by ``0.1`` is passing fragilely; one cleared by ``30`` is
+passing comfortably, and the difference matters when deciding whether to trust a
+whole batch.
+
+Only the ordered comparisons have a continuous margin (``greater_than``,
+``greater_equal_than``, ``less_than``, ``less_equal_than`` and ``between``).
+Equality, string and membership tests are discrete — there is no "how far" to
+report — so they are skipped. For a rule that is a single comparison the slack
+is exactly the rule's distance to flipping; for a compound rule it is reported
+per comparison, since the binding constraint then depends on the data.
+"""
+
+import dataclasses
+import typing
+
+from rich.console import Console
+from rich.markup import escape
+
+from auto_qc import models, node
+
+# Signed slack for each ordered comparison. The value is positive exactly when
+# the comparison holds, and its magnitude is the distance the compared value
+# must move to reach the boundary.
+_MARGIN: dict[str, typing.Callable[..., float]] = {
+    "greater_than": lambda value, bound: value - bound,
+    "greater_equal_than": lambda value, bound: value - bound,
+    "less_than": lambda value, bound: bound - value,
+    "less_equal_than": lambda value, bound: bound - value,
+    "between": lambda value, low, high: min(value - low, high - value),
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class Comparison:
+    """One numeric comparison within a rule, with its slack to the boundary."""
+
+    slack: float
+    holds: bool
+    description: str
+
+
+def _is_number(value: typing.Any) -> bool:
+    """Is ``value`` a real number we can measure a margin against (not a bool)?"""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _format_value(value: typing.Any) -> str:
+    """Render a resolved operand value compactly for the report."""
+    if isinstance(value, bool):
+        return repr(value)
+    if isinstance(value, float):
+        return f"{value:g}"
+    if isinstance(value, int):
+        return str(value)
+    return repr(value)
+
+
+def _describe_operand(trace: node.Trace) -> str:
+    """Describe one operand of a comparison, with its pointer resolved."""
+    if trace.kind == "variable":
+        return f"{trace.variable}={_format_value(trace.result)}"
+    if trace.kind in ("literal", "list"):
+        return _format_value(trace.result)
+    # A nested application, e.g. arithmetic feeding the comparison.
+    return f"{(trace.operator or '').lower()}(…)={_format_value(trace.result)}"
+
+
+def _describe(trace: node.Trace) -> str:
+    """Describe a comparison node, e.g. ``:coverage/mean_depth=30.1 greater_than 30``."""
+    name = (trace.operator or "").lower()
+    operands = [_describe_operand(child) for child in trace.children]
+    if name == "between":
+        return f"{operands[0]} between {operands[1]} and {operands[2]}"
+    return f"{operands[0]} {name} {operands[1]}"
+
+
+def collect(trace: node.Trace) -> list[Comparison]:
+    """Collect every measurable numeric comparison within ``trace``."""
+    comparisons: list[Comparison] = []
+    if trace.kind == "operator":
+        name = (trace.operator or "").lower()
+        values = [child.result for child in trace.children]
+        if name in _MARGIN and all(_is_number(value) for value in values):
+            comparisons.append(
+                Comparison(
+                    slack=float(_MARGIN[name](*values)),
+                    holds=bool(trace.result),
+                    description=_describe(trace),
+                )
+            )
+        for child in trace.children:
+            comparisons.extend(collect(child))
+    return comparisons
+
+
+def _slack_text(comparison: Comparison) -> str:
+    """Phrase a comparison's slack as passing room or a shortfall."""
+    magnitude = f"{abs(comparison.slack):g}"
+    return f"slack {magnitude}" if comparison.holds else f"short by {magnitude}"
+
+
+def render(state: models.AutoQC, console: Console) -> None:
+    """Print the slack of every numeric comparison in each rule."""
+    for threshold in state.thresholds:
+        trace = node.evaluate(threshold.rule, state.data)
+        status = "[bold green]PASS[/bold green]" if trace.result else "[bold red]FAIL[/bold red]"
+        console.print(
+            f"{status} {escape(threshold.name)} [dim]({escape(threshold.fail_code)})[/dim]"
+        )
+
+        comparisons = collect(trace)
+        if not comparisons:
+            console.print("    [dim]no numeric comparisons to measure[/dim]")
+            console.print()
+            continue
+
+        tightest = min(comparisons, key=lambda comparison: abs(comparison.slack))
+        for comparison in comparisons:
+            mark = "[green]✓[/green]" if comparison.holds else "[red]✗[/red]"
+            note = " [dim]← tightest[/dim]" if comparison is tightest else ""
+            console.print(
+                f"    {mark} {escape(comparison.description)} "
+                f"[dim]→[/dim] [yellow]{escape(_slack_text(comparison))}[/yellow]{note}"
+            )
+        console.print()

--- a/auto_qc/node.py
+++ b/auto_qc/node.py
@@ -30,6 +30,10 @@ class Operator:
     min_args: int
     max_args: int | None  # ``None`` means unbounded (variadic).
     kind: str  # Used to phrase type errors, e.g. "compare" / "do arithmetic on".
+    # Signed distance from the boundary for an ordered comparison: positive
+    # exactly when the comparison holds, its magnitude the amount the value must
+    # move to flip it. ``None`` for operators with no continuous margin.
+    margin: typing.Callable[..., float] | None = None
 
 
 def _product(values: typing.Iterable[float]) -> float:
@@ -38,13 +42,25 @@ def _product(values: typing.Iterable[float]) -> float:
 
 OPERATORS: dict[str, Operator] = {
     # Comparisons.
-    "greater_than": Operator(operator.gt, 2, 2, "compare"),
-    "greater_equal_than": Operator(operator.ge, 2, 2, "compare"),
-    "less_than": Operator(operator.lt, 2, 2, "compare"),
-    "less_equal_than": Operator(operator.le, 2, 2, "compare"),
+    "greater_than": Operator(
+        operator.gt, 2, 2, "compare", margin=lambda value, bound: value - bound
+    ),
+    "greater_equal_than": Operator(
+        operator.ge, 2, 2, "compare", margin=lambda value, bound: value - bound
+    ),
+    "less_than": Operator(operator.lt, 2, 2, "compare", margin=lambda value, bound: bound - value),
+    "less_equal_than": Operator(
+        operator.le, 2, 2, "compare", margin=lambda value, bound: bound - value
+    ),
     "equals": Operator(operator.eq, 2, 2, "compare"),
     "not_equals": Operator(operator.ne, 2, 2, "compare"),
-    "between": Operator(lambda v, lo, hi: lo <= v <= hi, 3, 3, "compare"),
+    "between": Operator(
+        lambda v, lo, hi: lo <= v <= hi,
+        3,
+        3,
+        "compare",
+        margin=lambda value, low, high: min(value - low, high - value),
+    ),
     # Boolean combinators. Their arguments are themselves rules.
     "and": Operator(lambda *args: all(args), 1, None, "combine"),
     "or": Operator(lambda *args: any(args), 1, None, "combine"),
@@ -133,6 +149,7 @@ class Trace:
     kind: str  # "operator" | "variable" | "literal" | "list"
     operator: str | None = None
     variable: str | None = None
+    margin: float | None = None
     children: list["Trace"] = dataclasses.field(default_factory=list)
 
     def to_dict(self) -> dict[str, typing.Any]:
@@ -143,11 +160,31 @@ class Trace:
             return {"literal": self.result}
         if self.kind == "list":
             return {"list": [child.to_dict() for child in self.children]}
-        return {
+        node_dict: dict[str, typing.Any] = {
             "operator": (self.operator or "").lower(),
             "result": self.result,
             "args": [child.to_dict() for child in self.children],
         }
+        if self.margin is not None:
+            node_dict["margin"] = self.margin
+        return node_dict
+
+
+def _is_number(value: typing.Any) -> bool:
+    """Is ``value`` a real number we can measure a margin against (not a bool)?"""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _margin(op: Operator, values: list[typing.Any]) -> float | None:
+    """The signed slack of an ordered comparison, or ``None`` if it has none.
+
+    Only the ordered comparisons carry a ``margin`` function, and only numeric
+    operands have a continuous distance to the boundary, so string comparisons
+    (``"b" > "a"``) report no margin.
+    """
+    if op.margin is None or not all(_is_number(value) for value in values):
+        return None
+    return float(op.margin(*values))
 
 
 def evaluate(expr: typing.Any, data: dict[str, typing.Any]) -> Trace:
@@ -164,8 +201,15 @@ def evaluate(expr: typing.Any, data: dict[str, typing.Any]) -> Trace:
         op_name = expr[0]
         op = OPERATORS[op_name.lower()]
         children = [evaluate(arg, data) for arg in expr[1:]]
-        result = _apply(op_name, op, [child.result for child in children])
-        return Trace(result=result, kind="operator", operator=op_name, children=children)
+        values = [child.result for child in children]
+        result = _apply(op_name, op, values)
+        return Trace(
+            result=result,
+            kind="operator",
+            operator=op_name,
+            margin=_margin(op, values),
+            children=children,
+        )
 
     if isinstance(expr, list):
         children = [evaluate(element, data) for element in expr]

--- a/features/outputs.feature
+++ b/features/outputs.feature
@@ -42,7 +42,8 @@ Scenario Outline: Generating JSON formatted output
                     "args": [
                         {"variable": ":value", "value": 2},
                         {"literal": <literal>}
-                    ]
+                    ],
+                    "margin": <margin>
                 },
                 "fail_code": "ERR00001",
                 "message": "<msg>",
@@ -56,9 +57,9 @@ Scenario Outline: Generating JSON formatted output
     """
 
 Examples: Outputs
-  | literal | pass   | msg    | code         | exit |
-  | 0       | true   | passes | []           | 0    |
-  | 2       | false  | fails  | ["ERR00001"] | 1    |
+  | literal | pass   | msg    | code         | exit | margin |
+  | 0       | true   | passes | []           | 0    | 2.0    |
+  | 2       | false  | fails  | ["ERR00001"] | 1    | 0.0    |
 
 Scenario: Explaining how a rule was evaluated
   Given I create the file "analysis.yml" with the contents:

--- a/features/outputs.feature
+++ b/features/outputs.feature
@@ -95,3 +95,31 @@ Scenario: Explaining how a rule was evaluated
     """
     18.6
     """
+
+Scenario: Reporting how close a rule is to flipping
+  Given I create the file "analysis.yml" with the contents:
+   """
+   coverage:
+     mean_depth: 30.1
+   """
+  And I create the file "threshold.yml" with the contents:
+   """
+   version: 3.0.0
+   thresholds:
+   - name: Coverage too low
+     fail_code: LOW_COVERAGE
+     rule:
+       - greater_than
+       - :coverage/mean_depth
+       - 30
+   """
+  When I run the command "auto-qc" with the arguments:
+     | key              | value         |
+     | --data           | analysis.yml  |
+     | --thresholds     | threshold.yml |
+     | --margin         |               |
+  Then the exit code should be 0
+  And the standard out should contain:
+    """
+    slack 0.1
+    """

--- a/test/test_evaluate.py
+++ b/test/test_evaluate.py
@@ -23,6 +23,7 @@ def test_build_passing_qc_node_with_two_literals():
             "operator": "greater_than",
             "result": True,
             "args": [{"literal": 2}, {"literal": 1}],
+            "margin": 1.0,
         },
     }
     assert qc.build_qc_node(threshold_node, {}) == expected
@@ -49,6 +50,7 @@ def test_build_failing_qc_node_with_literal_and_variable():
             "operator": "less_than",
             "result": False,
             "args": [{"variable": ":ref/metric_1", "value": 2}, {"literal": 1}],
+            "margin": -1.0,
         },
     }
     assert qc.build_qc_node(threshold_node, a) == expected

--- a/test/test_margin.py
+++ b/test/test_margin.py
@@ -1,0 +1,108 @@
+from rich.console import Console
+
+from auto_qc import core, margin, node
+
+
+def _collect(expr, data=None):
+    return margin.collect(node.evaluate(expr, data or {}))
+
+
+def test_passing_greater_than_reports_positive_slack():
+    [comparison] = _collect(["greater_than", ":depth", 30], {"depth": 40})
+    assert comparison.holds
+    assert comparison.slack == 10
+
+
+def test_failing_greater_than_reports_negative_slack():
+    [comparison] = _collect(["greater_than", ":depth", 30], {"depth": 18})
+    assert not comparison.holds
+    assert comparison.slack == -12
+
+
+def test_less_than_measures_distance_below_the_bound():
+    [comparison] = _collect(["less_than", ":contam", 1.0], {"contam": 0.4})
+    assert comparison.holds
+    assert round(comparison.slack, 1) == 0.6
+
+
+def test_between_uses_distance_to_the_nearest_bound():
+    [comparison] = _collect(["between", ":depth", 30, 60], {"depth": 31})
+    assert comparison.holds
+    assert comparison.slack == 1
+
+
+def test_between_below_range_is_a_deficit():
+    [comparison] = _collect(["between", ":depth", 30, 60], {"depth": 25})
+    assert not comparison.holds
+    assert comparison.slack == -5
+
+
+def test_equality_and_string_tests_have_no_margin():
+    assert _collect(["equals", ":protocol", "Standard"], {"protocol": "Standard"}) == []
+    assert _collect(["starts_with", ":id", "SRX"], {"id": "SRX-1"}) == []
+
+
+def test_collect_descends_into_boolean_combinators():
+    comparisons = _collect(
+        ["or", ["greater_than", ":a", 10], ["less_than", ":b", 5]],
+        {"a": 12, "b": 9},
+    )
+    assert len(comparisons) == 2
+    assert {round(c.slack) for c in comparisons} == {2, -4}
+
+
+def test_arithmetic_feeding_a_comparison_is_measured_once():
+    [comparison] = _collect(
+        ["greater_than", ["divide", ":mapped", ":total"], 0.9],
+        {"mapped": 95, "total": 100},
+    )
+    assert comparison.holds
+    assert round(comparison.slack, 2) == 0.05
+
+
+def _render(thresholds_doc, data):
+    state = core.build(thresholds_doc, data)
+    console = Console(record=True, width=100, force_terminal=False)
+    margin.render(state, console)
+    return console.export_text()
+
+
+def test_render_reports_slack_and_marks_the_tightest_comparison():
+    output = _render(
+        {
+            "version": "3.0.0",
+            "thresholds": [
+                {
+                    "name": "Coverage",
+                    "fail_code": "COVERAGE",
+                    "rule": [
+                        "and",
+                        ["greater_than", ":coverage/mean_depth", 30],
+                        ["greater_than", ":quality/percent_q30", 90],
+                    ],
+                }
+            ],
+        },
+        {"coverage": {"mean_depth": 30.1}, "quality": {"percent_q30": 99}},
+    )
+    assert "PASS" in output
+    assert "slack 0.1" in output
+    assert "slack 9" in output
+    assert "tightest" in output
+
+
+def test_render_notes_rules_without_numeric_comparisons():
+    output = _render(
+        {
+            "version": "3.0.0",
+            "thresholds": [
+                {
+                    "name": "Right protocol",
+                    "fail_code": "PROTOCOL",
+                    "rule": ["equals", ":sample/protocol", "Standard DNA"],
+                }
+            ],
+        },
+        {"sample": {"protocol": "Standard DNA"}},
+    )
+    assert "no numeric comparisons to measure" in output

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -105,7 +105,9 @@ def test_wrong_arity_raises_evaluation_error():
 
 def test_trace_to_dict_describes_the_evaluation():
     trace = node.evaluate(["greater_than", ":depth", 30], {"depth": 18.6})
-    assert trace.to_dict() == {
+    result = trace.to_dict()
+    assert result.pop("margin") == pytest.approx(-11.4)
+    assert result == {
         "operator": "greater_than",
         "result": False,
         "args": [
@@ -113,3 +115,18 @@ def test_trace_to_dict_describes_the_evaluation():
             {"literal": 30},
         ],
     }
+
+
+def test_trace_to_dict_includes_margin_only_for_ordered_comparisons():
+    trace = node.evaluate(["and", ["greater_than", 2, 1]], {})
+    result = trace.to_dict()
+    # The boolean combinator has no continuous margin ...
+    assert "margin" not in result
+    # ... but the comparison it wraps reports how far it cleared the boundary.
+    assert result["args"][0]["margin"] == 1
+
+
+def test_string_comparison_has_no_margin():
+    trace = node.evaluate(["greater_than", ":id", "SRX-1"], {"id": "SRX-2"})
+    assert trace.result is True
+    assert trace.margin is None


### PR DESCRIPTION
## What & why

`PASS`/`FAIL` tells you _whether_ a sample cleared the rules; this adds a way to ask _how robustly_. For every ordered numeric comparison, auto-qc now reports the **slack** — the distance the metric could move before that comparison flips. A coverage cutoff cleared by `0.1` is passing fragilely; one cleared by `30` is comfortable, a difference the bare verdict hides but that matters when deciding whether to trust a whole batch.

## What's in it

**A `--margin` / `-M` flag** that prints a per-rule report and marks the tightest comparison:

```
PASS Contamination too high (CONTAMINATION)
    ✓ :contamination/percent_human=0.4 less_than 1 → slack 0.6 ← tightest

FAIL Coverage below protocol threshold (LOW_COVERAGE)
    ✗ :coverage/mean_depth=12.4 greater_than 15 → short by 2.6 ← tightest
    ✗ :coverage/mean_depth=12.4 greater_than 30 → short by 17.6
```

Like `--explain`, it still exits `0` on pass and `1` on fail, so it slots into the same pipeline.

**The same margin on every ordered-comparison node of the `--json-output` `explain` tree** (a `margin` key alongside `operator`/`result`/`args`). This is what makes it useful at scale: the margins of a whole cohort can be aggregated — per rule — into a threshold-sensitivity dataset. Because the slack _is_ the distance to the boundary, counting samples whose margin falls in, say, `[-2, 0)` tells you exactly how many currently-failing samples a two-unit relaxation would reclaim.

## Design notes

- The slack functions live on the existing `Operator` metadata as the single source of truth; the evaluator computes the margin once and carries it on the `Trace`. Both the `--margin` view and the JSON read that same value — no second computation to drift.
- Only the ordered comparisons (`greater_than`, `greater_equal_than`, `less_than`, `less_equal_than`, `between`) have a continuous margin. Equality, string and membership tests are discrete and emit no margin.
- The JSON change is additive — a new optional key on comparison nodes only — so the existing schema is unchanged for consumers that ignore it.
- For a single-comparison rule the slack is exactly the verdict's distance to flipping; for a compound `and`/`or` rule it is reported per comparison.

## Tests & docs

- New `test/test_margin.py` (slack in both directions, `between`, boolean descent, arithmetic-fed comparisons, no-margin for discrete tests, rendering); updated the JSON-shape tests in `test_node.py` / `test_evaluate.py` and the `outputs.feature` scenario; added a `--margin` feature scenario.
- Docs: README (`--margin` option, a Margins section with the per-rule cohort-aggregation guidance, and `margin` in the JSON example), the man page, and a CHANGELOG entry under Unreleased.
- Full suite green: 69 unit tests, 59 feature scenarios, mypy, ruff + prettier.

https://claude.ai/code/session_01RESXet6rsHinwvSNBGpje9

---
_Generated by [Claude Code](https://claude.ai/code/session_01RESXet6rsHinwvSNBGpje9)_