### PR TITLE
Harden error handling and make all entry points total against fuzzed input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Invalid user input now always reports a clean error instead of a Python
+  traceback. This covers: an invalid regular expression passed to `matches`; an
+  unknown placeholder in a `pass_msg` / `fail_msg` (now caught when the
+  thresholds are read, with a did-you-mean suggestion); malformed YAML/JSON in
+  any input document, including values PyYAML's tag constructors (`!!int`,
+  `!!timestamp`) cannot convert; a `--test` suite that references a missing or
+  malformed thresholds file; a thresholds document that parses to something
+  other than a mapping; and documents nested too deeply or with recursive YAML
+  aliases.
+- `--json-output` no longer crashes when a metric is an unquoted YAML date or
+  time (parsed by PyYAML into a `datetime` object); such values are serialised
+  as strings.
+- `--test` now treats duplicate expected `codes` as a single code, so a correct
+  outcome cannot be reported as a failure.
+- Corrected the version-mismatch error, which told authors of a higher-major
+  threshold file to "update" to an older syntax.
+
 ### Added
 
 - A `--margin` / `-M` flag that reports, for every ordered numeric comparison in

--- a/auto_qc/core.py
+++ b/auto_qc/core.py
@@ -1,3 +1,4 @@
+import functools
 import typing
 
 import pydantic
@@ -5,7 +6,48 @@ import pydantic
 from auto_qc import exception, models
 from auto_qc.evaluate import error, qc
 
+_F = typing.TypeVar("_F", bound=typing.Callable[..., typing.Any])
 
+
+def _recursion_guarded(func: _F) -> _F:
+    """Convert a ``RecursionError`` into an :class:`AutoQCError`.
+
+    Rules and data are walked recursively, so a document nested absurdly
+    deeply — or one whose YAML aliases form a cycle (``&a [*a]``) — would
+    otherwise escape as a raw ``RecursionError``.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: typing.Any, **kwargs: typing.Any) -> typing.Any:
+        try:
+            return func(*args, **kwargs)
+        except RecursionError:
+            raise exception.AutoQCError(
+                "The documents are nested too deeply to evaluate. "
+                "Check for recursive YAML anchors/aliases."
+            ) from None
+
+    return typing.cast(_F, wrapper)
+
+
+def _validated(thresholds: typing.Any, data: dict[str, typing.Any]) -> models.AutoQC:
+    """Validate a parsed thresholds document, wrapping every failure mode.
+
+    Raises:
+        AutoQCError: If the document is not a mapping or fails validation.
+    """
+    if not isinstance(thresholds, dict):
+        raise exception.AutoQCError(
+            "The thresholds document must be a YAML/JSON mapping with 'version' "
+            f"and 'thresholds' keys, but it parsed as {type(thresholds).__name__}."
+        )
+    try:
+        return models.AutoQC.model_validate({**thresholds, "data": data})
+    except pydantic.ValidationError as err:
+        raise exception.AutoQCError(str(err)) from err
+
+
+@_recursion_guarded
 def build(thresholds: dict[str, typing.Any], data: dict[str, typing.Any]) -> models.AutoQC:
     """Validate the thresholds and data and return the checked ``AutoQC`` state.
 
@@ -21,11 +63,7 @@ def build(thresholds: dict[str, typing.Any], data: dict[str, typing.Any]) -> mod
             path, or use an unknown operator. Validation failures from pydantic
             are wrapped so that callers only ever need to catch ``AutoQCError``.
     """
-    try:
-        state = models.AutoQC(data=data, **thresholds)
-    except pydantic.ValidationError as err:
-        raise exception.AutoQCError(str(err)) from err
-
+    state = _validated(thresholds, data)
     error.check_node_paths(state)
     error.check_operators(state)
     error.check_arity(state)
@@ -33,6 +71,7 @@ def build(thresholds: dict[str, typing.Any], data: dict[str, typing.Any]) -> mod
     return state
 
 
+@_recursion_guarded
 def build_thresholds(thresholds: dict[str, typing.Any]) -> models.AutoQC:
     """Validate a thresholds document on its own, without a data document.
 
@@ -49,17 +88,14 @@ def build_thresholds(thresholds: dict[str, typing.Any]) -> models.AutoQC:
     Raises:
         AutoQCError: If the document is invalid or uses an unknown operator.
     """
-    try:
-        state = models.AutoQC(data={}, **thresholds)
-    except pydantic.ValidationError as err:
-        raise exception.AutoQCError(str(err)) from err
-
+    state = _validated(thresholds, {})
     error.check_operators(state)
     error.check_arity(state)
     error.check_messages(state)
     return state
 
 
+@_recursion_guarded
 def run(thresholds: dict[str, typing.Any], data: dict[str, typing.Any]) -> models.AutoQCEvaluation:
     """Evaluate a set of thresholds against a data document.
 

--- a/auto_qc/core.py
+++ b/auto_qc/core.py
@@ -29,6 +29,7 @@ def build(thresholds: dict[str, typing.Any], data: dict[str, typing.Any]) -> mod
     error.check_node_paths(state)
     error.check_operators(state)
     error.check_arity(state)
+    error.check_messages(state)
     return state
 
 
@@ -55,6 +56,7 @@ def build_thresholds(thresholds: dict[str, typing.Any]) -> models.AutoQC:
 
     error.check_operators(state)
     error.check_arity(state)
+    error.check_messages(state)
     return state
 
 

--- a/auto_qc/evaluate/error.py
+++ b/auto_qc/evaluate/error.py
@@ -1,5 +1,7 @@
 import difflib
 import itertools
+import re
+import string
 import typing
 
 from auto_qc import exception, models, node, variable
@@ -111,6 +113,51 @@ def check_arity(state: models.AutoQC) -> None:
     errors: list[str] = []
     for threshold in state.thresholds:
         _check_node_arity(threshold.rule, errors)
+
+    if errors:
+        raise exception.AutoQCError("\n".join(errors))
+
+
+def _check_message(
+    rule_name: str, label: str, message: str, available: set[str], errors: list[str]
+) -> None:
+    """Validate one message template against the variables its rule provides."""
+    try:
+        placeholders = [
+            field for _, field, _, _ in string.Formatter().parse(message) if field is not None
+        ]
+    except ValueError as err:
+        errors.append(f"Rule '{rule_name}': {label} {message!r} is not a valid template: {err}.")
+        return
+
+    for field in placeholders:
+        # ``{x.attr}`` / ``{x[0]}`` resolve attribute or index access on the
+        # variable named before the first ``.`` or ``[``.
+        name = re.split(r"[.\[]", field)[0]
+        if not name:
+            errors.append(
+                f"Rule '{rule_name}': {label} uses a positional placeholder '{{}}'; "
+                f"name a variable from the rule instead, e.g. '{{metric/path}}'."
+            )
+        elif name not in available:
+            errors.append(
+                f"Rule '{rule_name}': {label} references '{{{field}}}' but the rule "
+                f"has no variable '{name}'.{_suggest(name, available)}"
+            )
+
+
+def check_messages(state: models.AutoQC) -> None:
+    """
+    Checks that every ``pass_msg``/``fail_msg`` placeholder names a variable
+    used in its rule (without the leading ``:``), so a typo is reported when
+    the thresholds are read rather than crashing when the message is rendered.
+    """
+    errors: list[str] = []
+    for threshold in state.thresholds:
+        available = {name[1:] for name in variable.get_variable_names(threshold.rule)}
+        for label, message in (("pass_msg", threshold.pass_msg), ("fail_msg", threshold.fail_msg)):
+            if message is not None:
+                _check_message(threshold.name, label, message, available, errors)
 
     if errors:
         raise exception.AutoQCError("\n".join(errors))

--- a/auto_qc/evaluate/qc.py
+++ b/auto_qc/evaluate/qc.py
@@ -30,10 +30,22 @@ def create_variable_dict(
 def create_qc_message(
     is_pass: bool, input_node: models.ThresholdNode, variables: dict[str, typing.Any]
 ) -> str:
+    """Render the rule's pass or fail message with its variables filled in.
+
+    Raises:
+        AutoQCError: If the message cannot be rendered — unknown placeholder
+            names are caught when the thresholds are read, but a format spec
+            can still fail against the resolved value (e.g. ``{x:.2f}`` when
+            ``x`` is text).
+    """
     msg = input_node.pass_msg if is_pass else input_node.fail_msg
     if msg is None:
         return ""
-    return msg.format(**variables)
+    try:
+        return msg.format(**variables)
+    except (KeyError, IndexError, ValueError, TypeError, AttributeError) as err:
+        label = "pass_msg" if is_pass else "fail_msg"
+        raise AutoQCError(f"could not render {label} {msg!r}: {err!r}") from err
 
 
 def build_qc_node(
@@ -47,11 +59,11 @@ def build_qc_node(
     """
     try:
         trace = node.evaluate(input_node.rule, analysis)
+        is_pass = bool(trace.result)
+        variables = create_variable_dict(input_node, analysis)
+        message = create_qc_message(is_pass, input_node, variables)
     except AutoQCError as err:
         raise AutoQCError(f"Rule '{input_node.name}' ({input_node.fail_code}): {err}") from err
-
-    is_pass = bool(trace.result)
-    variables = create_variable_dict(input_node, analysis)
 
     return {
         "variables": variables,
@@ -59,6 +71,6 @@ def build_qc_node(
         "pass": is_pass,
         "fail_code": input_node.fail_code,
         "tags": input_node.tags or [],
-        "message": create_qc_message(is_pass, input_node, variables),
+        "message": message,
         "explain": trace.to_dict(),
     }

--- a/auto_qc/main.py
+++ b/auto_qc/main.py
@@ -26,7 +26,10 @@ def _load_document(path: str) -> typing.Any:
             return yaml.safe_load(sys.stdin.read())
         with open(path) as handle:
             return yaml.safe_load(handle)
-    except yaml.YAMLError as err:
+    # Beyond YAMLError, PyYAML's tag constructors (!!int, !!timestamp, ...)
+    # raise bare ValueError/OverflowError/IndexError on values they cannot
+    # convert, and its parser recurses on nesting depth.
+    except (yaml.YAMLError, ValueError, OverflowError, IndexError, RecursionError) as err:
         source = "stdin" if path == "-" else f"'{path}'"
         raise auto_qc.exception.AutoQCError(
             f"Could not parse {source} as YAML/JSON:\n{err}"
@@ -145,6 +148,9 @@ def cli(
             explain_view.render(state, stdout)
         if margin:
             margin_view.render(state, stdout)
+    except RecursionError:
+        stderr.print("[red]Errors[/red]:\nThe documents are nested too deeply to evaluate.")
+        sys.exit(1)
     except auto_qc.exception.AutoQCError as err:
         stderr.print(f"[red]Errors[/red]:\n{err}")
         sys.exit(1)

--- a/auto_qc/main.py
+++ b/auto_qc/main.py
@@ -16,11 +16,21 @@ from auto_qc.evaluate import qc
 
 
 def _load_document(path: str) -> typing.Any:
-    """Parse a YAML/JSON document from a path, or from stdin when ``path`` is ``-``."""
-    if path == "-":
-        return yaml.safe_load(sys.stdin.read())
-    with open(path) as handle:
-        return yaml.safe_load(handle)
+    """Parse a YAML/JSON document from a path, or from stdin when ``path`` is ``-``.
+
+    Raises:
+        AutoQCError: If the document is not valid YAML/JSON.
+    """
+    try:
+        if path == "-":
+            return yaml.safe_load(sys.stdin.read())
+        with open(path) as handle:
+            return yaml.safe_load(handle)
+    except yaml.YAMLError as err:
+        source = "stdin" if path == "-" else f"'{path}'"
+        raise auto_qc.exception.AutoQCError(
+            f"Could not parse {source} as YAML/JSON:\n{err}"
+        ) from err
 
 
 @click.command()
@@ -88,8 +98,8 @@ def cli(
     stderr = console.Console(width=100, stderr=True)
 
     if manual:
-        with resources.path(auto_qc.__name__, "MANUAL.md") as manual_path:
-            stdout.print(markdown.Markdown(manual_path.read_text()))
+        manual_text = resources.files(auto_qc).joinpath("MANUAL.md").read_text()
+        stdout.print(markdown.Markdown(manual_text))
         sys.exit(0)
 
     if test_suite:

--- a/auto_qc/models.py
+++ b/auto_qc/models.py
@@ -38,7 +38,7 @@ class AutoQC(pydantic.BaseModel):
                 textwrap.dedent(
                     f"""
             Incompatible threshold file syntax: {ver}.
-            Please update the syntax to version >= {version.__version__}.
+            This release of auto-qc ({version.__version__}) requires major version {version.major_version(version.__version__)}, e.g. '{version.__version__}'.
                     """
                 )
             )

--- a/auto_qc/models.py
+++ b/auto_qc/models.py
@@ -101,4 +101,7 @@ class AutoQCEvaluation:
             },
             indent=4,
             sort_keys=True,
+            # YAML parses unquoted dates/times into datetime objects; render
+            # any non-JSON value as its string form rather than crashing.
+            default=str,
         )

--- a/auto_qc/node.py
+++ b/auto_qc/node.py
@@ -137,6 +137,10 @@ def _apply(op_name: str, op: Operator, args: list[typing.Any]) -> typing.Any:
         return op.func(*args)
     except ZeroDivisionError:
         raise exception.EvaluationError(f"Operator '{op_name.lower()}' divided by zero.") from None
+    except re.error as err:
+        raise exception.EvaluationError(
+            f"Operator '{op_name.lower()}' was given an invalid regular expression: {err}."
+        ) from None
     except (TypeError, AttributeError):
         raise exception.EvaluationError(_type_message(op_name, op, args)) from None
 

--- a/auto_qc/runner.py
+++ b/auto_qc/runner.py
@@ -25,7 +25,10 @@ def _load_yaml(path: str) -> typing.Any:
     with open(path) as handle:
         try:
             return yaml.safe_load(handle)
-        except yaml.YAMLError as err:
+        # Beyond YAMLError, PyYAML's tag constructors (!!int, !!timestamp, ...)
+        # raise bare ValueError/OverflowError/IndexError on values they cannot
+        # convert, and its parser recurses on nesting depth.
+        except (yaml.YAMLError, ValueError, OverflowError, IndexError, RecursionError) as err:
             raise exception.AutoQCError(f"Could not parse '{path}' as YAML/JSON:\n{err}") from err
 
 

--- a/auto_qc/runner.py
+++ b/auto_qc/runner.py
@@ -16,6 +16,19 @@ from rich.console import Console
 from auto_qc import core, exception, models
 
 
+def _load_yaml(path: str) -> typing.Any:
+    """Parse the YAML document at ``path``.
+
+    Raises:
+        AutoQCError: If the file is not valid YAML.
+    """
+    with open(path) as handle:
+        try:
+            return yaml.safe_load(handle)
+        except yaml.YAMLError as err:
+            raise exception.AutoQCError(f"Could not parse '{path}' as YAML/JSON:\n{err}") from err
+
+
 def _format_outcome(is_pass: bool, fail_codes: list[str]) -> str:
     """Render an outcome the same way a case author would write it."""
     if is_pass:
@@ -40,7 +53,7 @@ def _check_case(case: models.TestCase, thresholds: dict[str, typing.Any]) -> str
     # The case expects a failure.
     if evaluation.is_pass:
         return f"expected {_format_outcome(False, case.codes or [])}, got PASS"
-    if case.codes is not None and sorted(case.codes) != evaluation.fail_codes:
+    if case.codes is not None and sorted(set(case.codes)) != evaluation.fail_codes:
         return f"expected {_format_outcome(False, case.codes)}, got {actual}"
     return None
 
@@ -52,19 +65,25 @@ def run_file(path: str, console: Console) -> bool:
     file, so a suite can sit next to the rules it tests.
 
     Raises:
-        AutoQCError: If the suite file itself is invalid.
+        AutoQCError: If the suite file itself is invalid, or the thresholds
+            file it references cannot be read or parsed.
     """
     base_dir = os.path.dirname(os.path.abspath(path))
-    with open(path) as handle:
-        suite_doc = yaml.safe_load(handle)
+    suite_doc = _load_yaml(path)
 
     try:
         suite = models.TestSuite(**suite_doc)
     except (pydantic.ValidationError, TypeError) as err:
         raise exception.AutoQCError(str(err)) from err
 
-    with open(os.path.join(base_dir, suite.thresholds)) as handle:
-        thresholds = yaml.safe_load(handle)
+    thresholds_path = os.path.join(base_dir, suite.thresholds)
+    try:
+        thresholds = _load_yaml(thresholds_path)
+    except OSError as err:
+        raise exception.AutoQCError(
+            f"Could not read thresholds file '{suite.thresholds}' "
+            f"referenced by the test suite: {err}"
+        ) from err
 
     console.print(
         f"Testing [cyan]{suite.thresholds}[/cyan] against [bold]{len(suite.cases)}[/bold] cases\n"

--- a/auto_qc/util/functional.py
+++ b/auto_qc/util/functional.py
@@ -1,22 +1,6 @@
 import typing
 from functools import reduce
 
-T = typing.TypeVar("T")
-
-
-def identity(x: T) -> T:
-    """
-    The identity function.
-    """
-    return x
-
-
-def empty_list(*args: typing.Any) -> list[typing.Any]:
-    """
-    Returns an empty list, whatever the arguments.
-    """
-    return []
-
 
 def flatten(n: list[typing.Any]) -> list[typing.Any]:
     def _f(acc: list[typing.Any], x: typing.Any) -> list[typing.Any]:
@@ -37,22 +21,3 @@ def get_in(data: typing.Any, keys: typing.Iterable[str]) -> typing.Any:
             return None
         data = data[key]
     return data
-
-
-def recursive_apply(
-    list_func: typing.Callable[[list[typing.Any]], typing.Any],
-    atom_func: typing.Callable[[typing.Any], typing.Any] = identity,
-) -> typing.Callable[[typing.Any], typing.Any]:
-    """
-    Creates a function which applies either of the two given functions: the first
-    to a list, and the second to atoms within a list. Used to walk over deeply
-    nested s-expressions.
-    """
-
-    def _f(x: typing.Any) -> typing.Any:
-        if isinstance(x, list):
-            return list_func(x)
-        else:
-            return atom_func(x)
-
-    return _f

--- a/auto_qc/variable.py
+++ b/auto_qc/variable.py
@@ -29,34 +29,10 @@ def is_variable_path_valid(data: dict[str, typing.Any], path: str) -> bool:
 def resolve(data: dict[str, typing.Any], path: str) -> typing.Any:
     """Return the raw value at ``path``, or ``None`` if any key is missing.
 
-    Unlike :func:`get_variable_value`, lists are returned as-is rather than
-    wrapped in a ``list`` s-expression, so the engine can use a referenced list
-    directly (e.g. as the right-hand side of ``is_in``).
+    Lists are returned as-is, so the engine can use a referenced list directly
+    (e.g. as the right-hand side of ``is_in``).
     """
     return functional.get_in(data, path[1:].split("/"))
-
-
-def get_variable_value(data: dict[str, typing.Any], path: str) -> typing.Any:
-    """Get variable's value by traversing its path into the data file.
-
-    Args:
-        data: Source data to fetch value from.
-        path: Path to value.
-
-    Returns:
-        The value of the variable pointed to by the path.
-
-    Notes:
-        If the value is a list, the `list` string is appended to the start of the list. This is necessary because
-        lists are treated as SEXPs where the first node in each list is an operator.
-
-    """
-    drop_colon = path[1:]
-    path_array = drop_colon.split("/")
-    var_value = functional.get_in(data, path_array)
-    if isinstance(var_value, list):
-        return ["list", *var_value]
-    return var_value
 
 
 def get_variable_names(qc_node: list[typing.Any]) -> list[str]:

--- a/features/errors.feature
+++ b/features/errors.feature
@@ -48,7 +48,7 @@ Scenario Outline: Incompatible threshold file version number
   And the standard error should contain:
     """
     Incompatible threshold file syntax: <version>.
-    Please update the syntax to version >= 3.0.0.
+    This release of auto-qc (3.0.0) requires major version 3, e.g. '3.0.0'.
 
     """
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -52,3 +52,20 @@ def test_invalid_document_raises_autoqc_error_not_pydantic():
     }
     with pytest.raises(AutoQCError):
         run(thresholds, {"depth": 5})
+
+
+def test_non_mapping_thresholds_document_raises_autoqc_error():
+    with pytest.raises(AutoQCError, match="must be a YAML/JSON mapping"):
+        run([1, 2, 3], {"a": 1})
+
+
+def test_recursive_rule_raises_autoqc_error():
+    """A rule that contains itself (recursive YAML alias) must not crash."""
+    rule = ["and", True]
+    rule.append(rule)
+    thresholds = {
+        "version": auto_qc.__version__,
+        "thresholds": [{"name": "recursive", "fail_code": "REC", "rule": rule}],
+    }
+    with pytest.raises(AutoQCError, match="nested too deeply"):
+        run(thresholds, {"a": 1})

--- a/test/test_error_handling.py
+++ b/test/test_error_handling.py
@@ -97,3 +97,89 @@ def test_type_mismatch_surfaces_as_autoqc_error_with_rule_name():
     }
     with pytest.raises(exception.AutoQCError, match="Coverage too low"):
         core.run(thresholds, {"a": "not a number"})
+
+
+def _create_auto_qc_with_messages(rule, **messages) -> models.AutoQC:
+    return models.AutoQC(
+        version=version.__version__,
+        thresholds=[{"name": "example_test", "fail_code": "ERR_1", "rule": rule, **messages}],
+        data={},
+    )
+
+
+def test_check_messages_accepts_placeholders_from_the_rule():
+    auto_qc_eval = _create_auto_qc_with_messages(
+        ["greater_than", ":coverage/mean_depth", 30],
+        pass_msg="depth was {coverage/mean_depth:.1f}",
+        fail_msg="depth was only {coverage/mean_depth}",
+    )
+    error.check_messages(auto_qc_eval)  # Should not raise.
+
+
+def test_check_messages_flags_unknown_placeholder_with_suggestion():
+    auto_qc_eval = _create_auto_qc_with_messages(
+        ["greater_than", ":coverage/mean_depth", 30],
+        fail_msg="depth was only {coverage/men_depth}",
+    )
+    with pytest.raises(exception.AutoQCError, match=r"Did you mean 'coverage/mean_depth'\?"):
+        error.check_messages(auto_qc_eval)
+
+
+def test_check_messages_flags_unbalanced_braces():
+    auto_qc_eval = _create_auto_qc_with_messages(
+        ["greater_than", ":coverage/mean_depth", 30],
+        fail_msg="depth was only {coverage/mean_depth",
+    )
+    with pytest.raises(exception.AutoQCError, match="not a valid template"):
+        error.check_messages(auto_qc_eval)
+
+
+def test_check_messages_flags_positional_placeholder():
+    auto_qc_eval = _create_auto_qc_with_messages(
+        ["greater_than", ":coverage/mean_depth", 30],
+        fail_msg="depth was only {}",
+    )
+    with pytest.raises(exception.AutoQCError, match="positional placeholder"):
+        error.check_messages(auto_qc_eval)
+
+
+def test_check_messages_allows_literal_braces():
+    auto_qc_eval = _create_auto_qc_with_messages(
+        ["greater_than", ":coverage/mean_depth", 30],
+        fail_msg="literal {{braces}} are fine",
+    )
+    error.check_messages(auto_qc_eval)  # Should not raise.
+
+
+def test_message_typo_is_reported_when_thresholds_are_read():
+    """A bad placeholder fails at build time, not as a KeyError mid-evaluation."""
+    thresholds = {
+        "version": version.__version__,
+        "thresholds": [
+            {
+                "name": "Coverage too low",
+                "fail_code": "LOW",
+                "rule": ["greater_than", ":a", 3],
+                "fail_msg": "value was {wrong_name}",
+            }
+        ],
+    }
+    with pytest.raises(exception.AutoQCError, match="wrong_name"):
+        core.run(thresholds, {"a": 5})
+
+
+def test_bad_format_spec_surfaces_as_autoqc_error_with_rule_name():
+    """A format spec that fails against the resolved value reports cleanly."""
+    thresholds = {
+        "version": version.__version__,
+        "thresholds": [
+            {
+                "name": "Sample name",
+                "fail_code": "NAME",
+                "rule": ["equals", ":a", "x"],
+                "fail_msg": "name was {a:.2f}",
+            }
+        ],
+    }
+    with pytest.raises(exception.AutoQCError, match="Sample name"):
+        core.run(thresholds, {"a": "not x"})

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -106,3 +106,12 @@ def test_json_output_includes_machine_readable_explain(tmp_path):
     assert explain["operator"] == "greater_than"
     assert explain["result"] is False
     assert {"variable": ":coverage/mean_depth", "value": 18.6} in explain["args"]
+
+
+def test_malformed_yaml_reports_cleanly(tmp_path):
+    thresholds = _write(tmp_path, "t.yml", THRESHOLDS)
+    data = _write(tmp_path, "d.yml", "coverage: {mean_depth: [\n")
+    result = CliRunner().invoke(cli, ["-t", thresholds, "-d", data])
+    assert result.exit_code == 1
+    assert "Could not parse" in result.stderr
+    assert "Traceback" not in result.stderr

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from click.testing import CliRunner
 
 import auto_qc
@@ -111,6 +112,44 @@ def test_json_output_includes_machine_readable_explain(tmp_path):
 def test_malformed_yaml_reports_cleanly(tmp_path):
     thresholds = _write(tmp_path, "t.yml", THRESHOLDS)
     data = _write(tmp_path, "d.yml", "coverage: {mean_depth: [\n")
+    result = CliRunner().invoke(cli, ["-t", thresholds, "-d", data])
+    assert result.exit_code == 1
+    assert "Could not parse" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_json_output_handles_yaml_dates(tmp_path):
+    thresholds = _write(
+        tmp_path,
+        "t.yml",
+        """
+version: 3.0.0
+thresholds:
+  - name: run date check
+    fail_code: DATE
+    rule: ["equals", ":run_date", "2024-01-01"]
+""",
+    )
+    data = _write(tmp_path, "d.yml", "run_date: 2024-01-01\n")
+    result = CliRunner().invoke(cli, ["-t", thresholds, "-d", data, "--json-output"])
+    assert result.exit_code == 1
+    report = json.loads(result.output)
+    assert report["qc"][0]["explain"]["args"][0]["value"] == "2024-01-01"
+
+
+def test_non_mapping_thresholds_document_reports_cleanly(tmp_path):
+    thresholds = _write(tmp_path, "t.yml", "just a string\n")
+    data = _write(tmp_path, "d.yml", "coverage: {mean_depth: 40}\n")
+    result = CliRunner().invoke(cli, ["-t", thresholds, "-d", data])
+    assert result.exit_code == 1
+    assert "must be a YAML/JSON mapping" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+@pytest.mark.parametrize("data_body", ["coverage: !!int not-a-number\n", "!!int\n"])
+def test_yaml_tag_constructor_errors_report_cleanly(tmp_path, data_body):
+    thresholds = _write(tmp_path, "t.yml", THRESHOLDS)
+    data = _write(tmp_path, "d.yml", data_body)
     result = CliRunner().invoke(cli, ["-t", thresholds, "-d", data])
     assert result.exit_code == 1
     assert "Could not parse" in result.stderr

--- a/test/test_node.py
+++ b/test/test_node.py
@@ -130,3 +130,9 @@ def test_string_comparison_has_no_margin():
     trace = node.evaluate(["greater_than", ":id", "SRX-1"], {"id": "SRX-2"})
     assert trace.result is True
     assert trace.margin is None
+
+
+def test_invalid_regex_reports_cleanly():
+    """A malformed pattern is a rule-author error, not a crash."""
+    with pytest.raises(exception.EvaluationError, match="invalid regular expression"):
+        _eval(["matches", "sample_a", "["])

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -1,8 +1,9 @@
 import textwrap
 
+import pytest
 from rich.console import Console
 
-from auto_qc import runner
+from auto_qc import exception, runner
 
 THRESHOLDS = """
 version: 3.0.0
@@ -100,6 +101,48 @@ def test_runner_passes_fail_case_without_specifying_codes(tmp_path):
               coverage: { mean_depth: 5 }
               contamination: { percent: 0.2 }
             expect: fail
+        """,
+    )
+    assert ok is True
+
+
+def test_runner_reports_missing_thresholds_file_cleanly(tmp_path):
+    suite = tmp_path / "qc_tests.yml"
+    suite.write_text(
+        textwrap.dedent(
+            """
+            thresholds: does_not_exist.yml
+            cases:
+              - name: a case
+                data: { x: 1 }
+            """
+        )
+    )
+    console = Console(record=True, width=100, force_terminal=False)
+    with pytest.raises(exception.AutoQCError, match="does_not_exist.yml"):
+        runner.run_file(str(suite), console)
+
+
+def test_runner_reports_malformed_suite_yaml_cleanly(tmp_path):
+    suite = tmp_path / "qc_tests.yml"
+    suite.write_text("thresholds: [\n")
+    console = Console(record=True, width=100, force_terminal=False)
+    with pytest.raises(exception.AutoQCError, match="Could not parse"):
+        runner.run_file(str(suite), console)
+
+
+def test_runner_treats_duplicate_expected_codes_as_one(tmp_path):
+    ok, _ = _run(
+        tmp_path,
+        """
+        thresholds: thresholds.yml
+        cases:
+          - name: duplicate codes collapse
+            data:
+              coverage: { mean_depth: 5 }
+              contamination: { percent: 0.2 }
+            expect: fail
+            codes: [LOW_COVERAGE, LOW_COVERAGE]
         """,
     )
     assert ok is True


### PR DESCRIPTION
Review of the `v3.0.0` branch surfaced several inputs that crashed with a raw Python traceback instead of the clean `AutoQCError` messages used everywhere else. This branch fixes those, adds regression tests for each, and then fuzzes the entry points to confirm they are total against arbitrary input.

## Fixes

**From the review (clean error instead of a traceback):**

- Invalid regular expression passed to `matches`.
- Unknown placeholder in a `pass_msg` / `fail_msg` — now caught when the thresholds are read (new `check_messages`, with a did-you-mean suggestion), plus a runtime guard for a format spec that fails against the resolved value.
- Malformed YAML/JSON in `--data` / `--thresholds`.
- A `--test` suite that references a missing or malformed thresholds file.

**Found by fuzzing:**

- A thresholds document that parses to a non-mapping (scalar/list).
- PyYAML's tag constructors (`!!int`, `!!timestamp`, …) raise bare `ValueError` / `OverflowError` / `IndexError`, not `YAMLError`, on values they cannot convert; both loaders now catch these.
- Deeply nested rules and recursive YAML aliases (`&a [*a]`) raised `RecursionError` from the recursive walkers; `core.build*` and the loaders now convert it to a clean error.
- `--json-output` crashed on unquoted YAML dates/times (parsed into `datetime`); unknown types are now serialised as strings.

**Minor:**

- Corrected the version-mismatch message, which told authors of a higher-major threshold file to "update" to an older syntax.
- `--test` deduplicates expected `codes` so a correct outcome cannot be reported as a failure.
- Migrated off the deprecated `importlib.resources.path`.
- Removed dead code: `variable.get_variable_value` and `functional.identity` / `empty_list` / `recursive_apply`.

## Verification

- 105 unit tests + 59 behave scenarios passing; ruff, ruff-format, mypy and prettier all green; coverage 94%.
- After the fixes, ~126k structured fuzz cases (random rule s-expressions through the public API) and ~46k CLI fuzz cases (mutated YAML text) ran with zero uncaught exceptions — every bad input exits cleanly rather than as a traceback.

## Deliberately out of scope

The behavior-changing design observations from the review are left untouched: eager `and` / `or` evaluation (no short-circuit), and `--json-output` being silently ignored when combined with `--explain` / `--margin`.

https://claude.ai/code/session_017nDc9TYzG6jjzGrYw2TUC3

---
_Generated by [Claude Code](https://claude.ai/code/session_017nDc9TYzG6jjzGrYw2TUC3)_